### PR TITLE
feat: adiciona tratamento global de erros e storage de produtos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Substituir o controle manual da padaria por um sistema digital com foco em:
 ## Escopo Atual
 
 - **Fase 1:** backend + banco de dados
-- **Status atual:** estrutura inicial da API, schema do Prisma, seed e `/health`
+- **Status atual:** estrutura inicial da API, schema do Prisma, seed, `/health` e error handling global
 - **Frontend:** ainda não iniciado nesta etapa
 
 ## Stack do Projeto
@@ -38,8 +38,12 @@ Substituir o controle manual da padaria por um sistema digital com foco em:
 |   |   |-- src
 |   |   |   |-- config
 |   |   |   |   `-- prisma.js
+|   |   |   |-- middlewares
+|   |   |   |   `-- errorHandler.js
 |   |   |   |-- routes
 |   |   |   |   `-- index.js
+|   |   |   |-- utils
+|   |   |   |   `-- AppError.js
 |   |   |   |-- app.js
 |   |   |   |-- README.md
 |   |   |   `-- server.js
@@ -55,6 +59,7 @@ Substituir o controle manual da padaria por um sistema digital com foco em:
 |-- docs
 |   |-- projeto
 |   |   |-- README.md
+|   |   |-- codificacao-diagrama-classes.md
 |   |   |-- contexto-projeto.md
 |   |   |-- documentacao-completa-padaria-pao-fresquim.pdf
 |   |   `-- issues-fase1-backend.md
@@ -92,6 +97,7 @@ Resumo:
 ## Documentação de Referência
 
 - [Contexto do projeto](./docs/projeto/contexto-projeto.md)
+- [Codificação do diagrama de classes](./docs/projeto/codificacao-diagrama-classes.md)
 - [Backlog detalhado da Fase 1](./docs/projeto/issues-fase1-backend.md)
 - [Documentação completa em PDF](./docs/projeto/documentacao-completa-padaria-pao-fresquim.pdf)
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -19,3 +19,10 @@ TRANSACTION_DATABASE_URL="postgresql://postgres.jzryonfvdsmnkzkiclpj:[YOUR-PASSW
 JWT_SECRET="change-me"
 # Tempo padrão de expiração dos tokens.
 JWT_EXPIRES_IN="1d"
+
+# URL pública do projeto Supabase, usada futuramente para montar URLs de arquivos.
+SUPABASE_PROJECT_URL="https://your-project.supabase.co"
+# Chave administrativa para uploads server-side no bucket.
+SUPABASE_SERVICE_ROLE_KEY="[YOUR-SERVICE-ROLE-KEY]"
+# Nome do bucket público reservado para imagens de produtos.
+SUPABASE_STORAGE_BUCKET_PRODUTOS="produtos"

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -9,7 +9,8 @@ Nesta fase, o backend foi preparado para:
 - conectar no PostgreSQL hospedado no Supabase;
 - modelar o banco com Prisma;
 - popular o banco com dados iniciais;
-- expor um endpoint mínimo de verificação da API.
+- expor um endpoint mínimo de verificação da API;
+- padronizar o retorno de erros da aplicação.
 
 ## Responsabilidades futuras
 
@@ -35,6 +36,7 @@ Nesta fase, o backend foi preparado para:
 - `prisma.config.ts` configurado para uso da conexão direta na CLI;
 - seed inicial com funcionários, clientes, produtos, contas de fiado e vendas;
 - endpoint `GET /health` para validar a subida do serviço;
+- tratamento global de erros com `AppError` e middleware centralizado;
 - integração local testada com `prisma validate`, `prisma db push`, `prisma seed` e `/health`.
 
 ## Estrutura principal
@@ -47,8 +49,12 @@ apps/api
 ├── src
 │   ├── config
 │   │   └── prisma.js
+│   ├── middlewares
+│   │   └── errorHandler.js
 │   ├── routes
 │   │   └── index.js
+│   ├── utils
+│   │   └── AppError.js
 │   ├── app.js
 │   └── server.js
 ├── .env.example
@@ -62,8 +68,12 @@ apps/api
 - `prisma/seed.js`: carga inicial de dados para desenvolvimento
 - `src/config/prisma.js`: inicialização do Prisma Client
 - `src/routes/index.js`: rota `/health`
+- `src/utils/AppError.js`: classe para erros controlados da aplicação
+- `src/middlewares/errorHandler.js`: middleware global que padroniza respostas de erro
 - `.env.example`: modelo das variáveis de ambiente do backend
 - `prisma.config.ts`: configuração da CLI do Prisma 7
+- `sql/setup-storage-produtos.sql`: definição idempotente do bucket de imagens de produtos
+- `scripts/setup-storage-produtos.js`: executor para provisionar o bucket no Supabase
 
 ## Scripts disponíveis
 
@@ -89,6 +99,9 @@ Também ficam definidos:
 - `NODE_ENV`
 - `JWT_SECRET`
 - `JWT_EXPIRES_IN`
+- `SUPABASE_PROJECT_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_STORAGE_BUCKET_PRODUTOS`
 
 ## Como subir o backend
 
@@ -140,13 +153,25 @@ npm run prisma:db:push --workspace @padaria/api
 npm run prisma:seed --workspace @padaria/api
 ```
 
-### 6. Subir a API em ambiente local
+### 6. Provisionar o bucket de imagens dos produtos
+
+```bash
+npm run storage:setup --workspace @padaria/api
+```
+
+Esse passo cria o bucket público `produtos` no Supabase com:
+
+- limite de 5 MB por arquivo;
+- tipos permitidos `image/jpeg`, `image/png`, `image/webp` e `image/avif`;
+- políticas básicas para usuários autenticados fazerem upload, atualização e remoção futuramente.
+
+### 7. Subir a API em ambiente local
 
 ```bash
 npm run dev --workspace @padaria/api
 ```
 
-### 7. Testar se a API está online
+### 8. Testar se a API está online
 
 Abra no navegador, Postman ou Insomnia:
 
@@ -170,12 +195,13 @@ Pronto nesta etapa:
 - banco modelado;
 - tabelas sincronizadas no Supabase;
 - seed inicial funcionando;
-- API mínima respondendo `GET /health`.
+- API mínima respondendo `GET /health`;
+- tratamento global de erros preparado para Zod, Prisma e erros customizados;
+- provisionamento do bucket de imagens de produtos automatizado.
 
 Ainda não iniciado:
 
 - autenticação;
-- middlewares de erro;
 - CRUDs;
 - regras completas de negócio;
 - relatórios.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,7 +12,8 @@
     "prisma:studio": "prisma studio",
     "prisma:db:push": "prisma db push",
     "prisma:validate": "prisma validate",
-    "prisma:seed": "node prisma/seed.js"
+    "prisma:seed": "node prisma/seed.js",
+    "storage:setup": "node scripts/setup-storage-produtos.js"
   },
   "devDependencies": {
     "nodemon": "^3.1.14",

--- a/apps/api/scripts/setup-storage-produtos.js
+++ b/apps/api/scripts/setup-storage-produtos.js
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import dotenv from "dotenv";
+import { Client } from "pg";
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const envFilePath = path.resolve(currentDir, "../.env");
+const sqlFilePath = path.resolve(currentDir, "../sql/setup-storage-produtos.sql");
+
+// Carrega as variáveis locais da API antes de abrir a conexão administrativa.
+dotenv.config({ path: envFilePath });
+
+const connectionString = process.env.DIRECT_URL ?? process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error("DIRECT_URL ou DATABASE_URL precisa estar definido para configurar o bucket.");
+}
+
+const sql = await fs.readFile(sqlFilePath, "utf8");
+const client = new Client({ connectionString });
+
+await client.connect();
+
+try {
+  // Executa o SQL idempotente que cria o bucket e as políticas necessárias.
+  await client.query(sql);
+
+  // Confirma a configuração final retornando apenas os dados relevantes do bucket.
+  const result = await client.query(
+    `
+      select id, name, public, file_size_limit, allowed_mime_types
+      from storage.buckets
+      where id = 'produtos'
+    `,
+  );
+
+  console.log(JSON.stringify(result.rows[0], null, 2));
+} finally {
+  await client.end();
+}

--- a/apps/api/sql/setup-storage-produtos.sql
+++ b/apps/api/sql/setup-storage-produtos.sql
@@ -1,0 +1,85 @@
+-- Cria ou atualiza o bucket público de imagens de produtos.
+insert into storage.buckets (
+  id,
+  name,
+  public,
+  file_size_limit,
+  allowed_mime_types,
+  type
+)
+values (
+  'produtos',
+  'produtos',
+  true,
+  5242880,
+  array['image/jpeg', 'image/png', 'image/webp', 'image/avif'],
+  'STANDARD'
+)
+on conflict (id) do update
+set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types,
+  type = excluded.type,
+  updated_at = now();
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'Produtos autenticados podem listar imagens'
+  ) then
+    create policy "Produtos autenticados podem listar imagens"
+    on storage.objects
+    for select
+    to authenticated
+    using (bucket_id = 'produtos');
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'Produtos autenticados podem enviar imagens'
+  ) then
+    create policy "Produtos autenticados podem enviar imagens"
+    on storage.objects
+    for insert
+    to authenticated
+    with check (bucket_id = 'produtos');
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'Produtos autenticados podem atualizar imagens'
+  ) then
+    create policy "Produtos autenticados podem atualizar imagens"
+    on storage.objects
+    for update
+    to authenticated
+    using (bucket_id = 'produtos')
+    with check (bucket_id = 'produtos');
+  end if;
+
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'Produtos autenticados podem remover imagens'
+  ) then
+    create policy "Produtos autenticados podem remover imagens"
+    on storage.objects
+    for delete
+    to authenticated
+    using (bucket_id = 'produtos');
+  end if;
+end
+$$;

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -3,6 +3,7 @@ import express from "express";
 import helmet from "helmet";
 import morgan from "morgan";
 
+import { errorHandler } from "./middlewares/errorHandler.js";
 import { router } from "./routes/index.js";
 
 export function createApp() {
@@ -20,6 +21,8 @@ export function createApp() {
 
   // Concentra todas as rotas da aplicação em um único ponto de entrada.
   app.use(router);
+  // Registra o tratamento global de erros como último middleware da aplicação.
+  app.use(errorHandler);
 
   return app;
 }

--- a/apps/api/src/middlewares/errorHandler.js
+++ b/apps/api/src/middlewares/errorHandler.js
@@ -1,0 +1,119 @@
+import { Prisma } from "@prisma/client";
+
+import { AppError } from "../utils/AppError.js";
+
+// Monta o formato padrão de resposta de erro da API.
+function buildErrorResponse(message, details) {
+  const response = {
+    error: message,
+  };
+
+  // Só adiciona detalhes quando existir algo útil para retornar ao cliente.
+  if (details?.length) {
+    response.details = details;
+  }
+
+  return response;
+}
+
+// Detecta erros de validação do Zod sem acoplar a aplicação a uma importação direta.
+function isZodValidationError(error) {
+  return error?.name === "ZodError" && Array.isArray(error?.issues);
+}
+
+// Converte os problemas do Zod para um formato simples e previsível na resposta.
+function formatZodIssues(issues) {
+  return issues.map((issue) => ({
+    field: issue.path.join("."),
+    message: issue.message,
+  }));
+}
+
+// Extrai os campos envolvidos em uma violação de unicidade do Prisma.
+function getUniqueConstraintFields(error) {
+  const target = error?.meta?.target;
+
+  if (Array.isArray(target) && target.length > 0) {
+    return target.join(", ");
+  }
+
+  return "informado";
+}
+
+// Extrai o campo de chave estrangeira para facilitar a leitura do erro retornado.
+function getForeignKeyField(error) {
+  const fieldName = error?.meta?.field_name;
+
+  if (typeof fieldName === "string" && fieldName.trim()) {
+    return fieldName;
+  }
+
+  return "relacionamento informado";
+}
+
+// Identifica erros conhecidos do Prisma mesmo quando eles chegam como objetos simples.
+function getPrismaErrorCode(error) {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    return error.code;
+  }
+
+  if (typeof error?.code === "string" && error.code.startsWith("P")) {
+    return error.code;
+  }
+
+  return null;
+}
+
+export function errorHandler(error, _request, response, _next) {
+  // Trata erros gerados manualmente pela própria aplicação.
+  if (error instanceof AppError) {
+    return response
+      .status(error.statusCode)
+      .json(buildErrorResponse(error.message));
+  }
+
+  // Trata erros de validação do Zod retornando os campos problemáticos.
+  if (isZodValidationError(error)) {
+    return response.status(400).json(
+      buildErrorResponse("Dados de entrada inválidos.", formatZodIssues(error.issues)),
+    );
+  }
+
+  // Centraliza o mapeamento de erros conhecidos do Prisma para respostas legíveis.
+  switch (getPrismaErrorCode(error)) {
+    case "P2025":
+      return response
+        .status(404)
+        .json(buildErrorResponse("Registro não encontrado."));
+
+    case "P2002": {
+      const fields = getUniqueConstraintFields(error);
+
+      return response.status(409).json(
+        buildErrorResponse(
+          `Já existe um registro com o valor informado para o campo ${fields}.`,
+        ),
+      );
+    }
+
+    case "P2003": {
+      const field = getForeignKeyField(error);
+
+      return response.status(400).json(
+        buildErrorResponse(
+          `Operação inválida: a referência do campo ${field} não existe.`,
+        ),
+      );
+    }
+
+    default:
+      break;
+  }
+
+  // Mantém o log dos erros inesperados no servidor para investigação posterior.
+  console.error(error);
+
+  return response
+    .status(500)
+    .json(buildErrorResponse("Erro interno do servidor."));
+}

--- a/apps/api/src/utils/AppError.js
+++ b/apps/api/src/utils/AppError.js
@@ -1,0 +1,14 @@
+// Classe base para erros de negócio controlados pela aplicação.
+export class AppError extends Error {
+  constructor(message, statusCode) {
+    super(message);
+
+    // Nome explícito para facilitar a identificação do erro em logs e middlewares.
+    this.name = "AppError";
+    // Status HTTP que deve ser devolvido quando esse erro for lançado.
+    this.statusCode = statusCode;
+
+    // Remove frames internos da stack para deixar o rastreio mais limpo.
+    Error.captureStackTrace?.(this, AppError);
+  }
+}

--- a/docs/projeto/README.md
+++ b/docs/projeto/README.md
@@ -6,6 +6,7 @@ Diretório com os artefatos centrais de referência do projeto.
 
 - [`contexto-projeto.md`](./contexto-projeto.md): resumo executivo do sistema, fases, stack e domínio
 - [`issues-fase1-backend.md`](./issues-fase1-backend.md): backlog detalhado da Fase 1
+- [`codificacao-diagrama-classes.md`](./codificacao-diagrama-classes.md): registro da codificação do diagrama de classes no Prisma
 - [`documentacao-completa-padaria-pao-fresquim.pdf`](./documentacao-completa-padaria-pao-fresquim.pdf): documentação oficial completa com requisitos, casos de uso, diagramas e mockups
 
 ## Observação

--- a/docs/projeto/codificacao-diagrama-classes.md
+++ b/docs/projeto/codificacao-diagrama-classes.md
@@ -1,0 +1,67 @@
+# Codificação do Diagrama de Classes
+
+Este documento registra como o diagrama de classes da documentação oficial foi traduzido para código na base inicial do backend.
+
+## Local da Implementação
+
+A codificação das classes principais foi feita no schema do Prisma:
+
+- [`apps/api/prisma/schema.prisma`](../../apps/api/prisma/schema.prisma)
+
+O Prisma foi usado como camada de modelagem porque a primeira fase do projeto tem foco em backend e banco de dados. Dessa forma, cada classe principal do domínio foi representada como um `model`, com seus atributos, tipos, chaves e relacionamentos.
+
+## Classes Codificadas
+
+As classes/entidades centrais codificadas foram:
+
+- `Cliente`
+- `Funcionario`
+- `Produto`
+- `Venda`
+- `ItemVenda`
+- `ContaFiado`
+- `RegistroPonto`
+- `Ferias`
+- `Licenca`
+- `Atestado`
+
+## Enums Codificados
+
+Também foram codificados enums de domínio usados pelas classes:
+
+- `Role`
+- `FormaPagamento`
+- `StatusSerasa`
+- `StatusNotificacao`
+- `TipoRegistroPonto`
+- `StatusVenda`
+
+## Relacionamentos Implementados
+
+Os principais relacionamentos do domínio também foram representados:
+
+- `Cliente` possui zero ou uma `ContaFiado`
+- `Cliente` possui várias `Venda`
+- `Funcionario` possui várias `Venda`
+- `Funcionario` possui vários `RegistroPonto`
+- `Funcionario` possui vários registros de `Ferias`, `Licenca` e `Atestado`
+- `Venda` possui vários `ItemVenda`
+- `Produto` possui vários `ItemVenda`
+- `ItemVenda` liga `Venda` e `Produto` por chave composta
+
+## Escopo da Entrega
+
+Esta entrega cobre a codificação estrutural do diagrama de classes na camada de domínio e persistência.
+
+Não fazem parte desta entrega:
+
+- CRUDs
+- autenticação JWT
+- controllers
+- services
+- interface gráfica
+- regras completas de negócio
+- relatórios
+- integrações externas
+
+Esses itens serão implementados nas próximas etapas do cronograma do projeto.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "prisma:validate": "npm run prisma:validate --workspace @padaria/api",
     "prisma:db:push": "npm run prisma:db:push --workspace @padaria/api",
     "prisma:studio": "npm run prisma:studio --workspace @padaria/api",
-    "prisma:seed": "npm run prisma:seed --workspace @padaria/api"
+    "prisma:seed": "npm run prisma:seed --workspace @padaria/api",
+    "storage:setup": "npm run storage:setup --workspace @padaria/api"
   },
   "workspaces": [
     "apps/*"


### PR DESCRIPTION
## Resumo
- implementa `AppError` e middleware global de tratamento de erros
- padroniza respostas no formato `{ error, details? }`
- trata erros Zod, Prisma `P2025`, `P2002`, `P2003`, `AppError` e erro genérico
- adiciona provisionamento idempotente do bucket `produtos` no Supabase Storage
- documenta a codificação do diagrama de classes no Prisma
- atualiza README raiz, README da API e `.env.example`

## Validações
- `npm run prisma:validate`
- `npm run storage:setup`
- `GET http://localhost:3333/health`

Closes #2