### PR TITLE
feat: adiciona classes iniciais do backend

### DIFF
--- a/apps/api/src/domain/entities/Cliente.js
+++ b/apps/api/src/domain/entities/Cliente.js
@@ -1,0 +1,60 @@
+// Importa o enum usado para indicar a situacao financeira do cliente.
+import { StatusSerasa } from "../enums.js";
+
+// Classe inicial que representa um cliente no dominio do backend.
+export class Cliente {
+  // Construtor da classe, recebendo os dados em formato de objeto.
+  constructor({
+    // Identificador do cliente no banco; antes de salvar pode ser nulo.
+    id = null,
+    // Nome completo do cliente.
+    nome,
+    // Telefone usado para contato e busca.
+    telefone,
+    // Endereco do cliente.
+    endereco,
+    // CPF do cliente.
+    cpf,
+    // Situacao do cliente no Serasa; por padrao comeca regular.
+    statusSerasa = StatusSerasa.REGULAR,
+    // Indica se o cliente esta ativo no sistema.
+    ativo = true,
+    // Conta de fiado vinculada ao cliente, quando existir.
+    contaFiado = null,
+    // Vendas vinculadas ao cliente, quando forem carregadas.
+    vendas = [],
+    // Data de criacao do registro, preenchida pela camada de persistencia.
+    criadoEm = null,
+    // Data da ultima atualizacao, preenchida pela camada de persistencia.
+    atualizadoEm = null,
+  }) {
+    // Armazena o identificador do cliente.
+    this.id = id;
+    // Armazena o nome do cliente.
+    this.nome = nome;
+    // Armazena o telefone do cliente.
+    this.telefone = telefone;
+    // Armazena o endereco do cliente.
+    this.endereco = endereco;
+    // Armazena o CPF do cliente.
+    this.cpf = cpf;
+    // Armazena a situacao do cliente no Serasa.
+    this.statusSerasa = statusSerasa;
+    // Armazena se o cliente esta ativo.
+    this.ativo = ativo;
+    // Armazena a conta de fiado associada.
+    this.contaFiado = contaFiado;
+    // Armazena as vendas associadas.
+    this.vendas = vendas;
+    // Armazena a data de criacao.
+    this.criadoEm = criadoEm;
+    // Armazena a data da ultima atualizacao.
+    this.atualizadoEm = atualizadoEm;
+  }
+
+  // Verifica se o cliente esta negativado.
+  estaNegativado() {
+    // Retorna verdadeiro quando o status for NEGATIVADO.
+    return this.statusSerasa === StatusSerasa.NEGATIVADO;
+  }
+}

--- a/apps/api/src/domain/entities/Funcionario.js
+++ b/apps/api/src/domain/entities/Funcionario.js
@@ -1,0 +1,96 @@
+// Importa o enum usado para definir o perfil de acesso do funcionario.
+import { Role } from "../enums.js";
+
+// Classe inicial que representa um funcionario no dominio do backend.
+export class Funcionario {
+  // Construtor da classe, recebendo os dados em formato de objeto.
+  constructor({
+    // Identificador do funcionario no banco; antes de salvar pode ser nulo.
+    id = null,
+    // Nome completo do funcionario.
+    nome,
+    // CPF do funcionario.
+    cpf,
+    // Telefone de contato do funcionario.
+    telefone,
+    // Endereco do funcionario.
+    endereco,
+    // Matricula interna do funcionario.
+    matricula,
+    // Cargo exercido pelo funcionario.
+    cargo,
+    // Data em que o funcionario foi admitido.
+    dataAdmissao,
+    // Contato de emergencia informado no cadastro.
+    contatoEmergencia,
+    // Perfil de acesso do funcionario; por padrao comeca como atendente.
+    role = Role.ATENDENTE,
+    // E-mail usado futuramente no login.
+    email,
+    // Hash da senha; a senha pura nao deve ser armazenada.
+    senhaHash,
+    // Indica se o funcionario esta ativo no sistema.
+    ativo = true,
+    // Vendas vinculadas ao funcionario, quando forem carregadas.
+    vendas = [],
+    // Registros de ponto vinculados ao funcionario.
+    registrosPonto = [],
+    // Periodos de ferias vinculados ao funcionario.
+    ferias = [],
+    // Licencas vinculadas ao funcionario.
+    licencas = [],
+    // Atestados vinculados ao funcionario.
+    atestados = [],
+    // Data de criacao do registro, preenchida pela camada de persistencia.
+    criadoEm = null,
+    // Data da ultima atualizacao, preenchida pela camada de persistencia.
+    atualizadoEm = null,
+  }) {
+    // Armazena o identificador do funcionario.
+    this.id = id;
+    // Armazena o nome do funcionario.
+    this.nome = nome;
+    // Armazena o CPF do funcionario.
+    this.cpf = cpf;
+    // Armazena o telefone do funcionario.
+    this.telefone = telefone;
+    // Armazena o endereco do funcionario.
+    this.endereco = endereco;
+    // Armazena a matricula do funcionario.
+    this.matricula = matricula;
+    // Armazena o cargo do funcionario.
+    this.cargo = cargo;
+    // Armazena a data de admissao.
+    this.dataAdmissao = dataAdmissao;
+    // Armazena o contato de emergencia.
+    this.contatoEmergencia = contatoEmergencia;
+    // Armazena o perfil de acesso.
+    this.role = role;
+    // Armazena o e-mail.
+    this.email = email;
+    // Armazena o hash da senha.
+    this.senhaHash = senhaHash;
+    // Armazena se o funcionario esta ativo.
+    this.ativo = ativo;
+    // Armazena as vendas associadas.
+    this.vendas = vendas;
+    // Armazena os registros de ponto associados.
+    this.registrosPonto = registrosPonto;
+    // Armazena os periodos de ferias associados.
+    this.ferias = ferias;
+    // Armazena as licencas associadas.
+    this.licencas = licencas;
+    // Armazena os atestados associados.
+    this.atestados = atestados;
+    // Armazena a data de criacao.
+    this.criadoEm = criadoEm;
+    // Armazena a data da ultima atualizacao.
+    this.atualizadoEm = atualizadoEm;
+  }
+
+  // Verifica se o funcionario possui perfil de proprietario.
+  ehProprietario() {
+    // Retorna verdadeiro quando o perfil for PROPRIETARIO.
+    return this.role === Role.PROPRIETARIO;
+  }
+}

--- a/apps/api/src/domain/entities/index.js
+++ b/apps/api/src/domain/entities/index.js
@@ -1,0 +1,4 @@
+// Exporta a classe Cliente para uso em outras partes do backend.
+export { Cliente } from "./Cliente.js";
+// Exporta a classe Funcionario para uso em outras partes do backend.
+export { Funcionario } from "./Funcionario.js";

--- a/apps/api/src/domain/enums.js
+++ b/apps/api/src/domain/enums.js
@@ -1,0 +1,17 @@
+// Enum com os perfis de acesso previstos para os funcionarios.
+export const Role = Object.freeze({
+  // Perfil do proprietario, com acesso administrativo completo.
+  PROPRIETARIO: "PROPRIETARIO",
+  // Perfil do atendente, usado para vendas e atendimento ao cliente.
+  ATENDENTE: "ATENDENTE",
+  // Perfil do padeiro, usado para operacoes ligadas aos produtos.
+  PADEIRO: "PADEIRO",
+});
+
+// Enum com a situacao do cliente para regras de fiado.
+export const StatusSerasa = Object.freeze({
+  // Cliente sem restricao.
+  REGULAR: "REGULAR",
+  // Cliente com restricao, usado para bloquear fiado.
+  NEGATIVADO: "NEGATIVADO",
+});

--- a/apps/api/src/domain/index.js
+++ b/apps/api/src/domain/index.js
@@ -1,0 +1,4 @@
+// Reexporta as classes iniciais do dominio.
+export * from "./entities/index.js";
+// Reexporta os enums usados pelas classes iniciais.
+export * from "./enums.js";


### PR DESCRIPTION
## Resumo
- adiciona a camada inicial `src/domain` no backend
- cria apenas as classes iniciais `Cliente` e `Funcionario`
- cria os enums necessários `Role` e `StatusSerasa`
- deixa os arquivos comentados em português para guiar a continuação manual pelo time

## Validações
- importação das classes via `apps/api/src/domain/index.js`
- `npm run prisma:validate`
- `GET http://localhost:3333/health`