### PR TITLE
feat(web): evolui clientes, produtos e dashboard

### DIFF
--- a/apps/api/src/config/prisma.js
+++ b/apps/api/src/config/prisma.js
@@ -1,10 +1,10 @@
+import "dotenv/config";
+
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
 
 // O adapter usa o driver pg por baixo e conecta no Postgres/Supabase via string de conexão.
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
-});
+const adapter = new PrismaPg(process.env.DATABASE_URL);
 
 // O PrismaClient é exportado como singleton local para ser reutilizado em toda a API.
 export const prisma = new PrismaClient({ adapter });

--- a/apps/api/src/services/clienteService.js
+++ b/apps/api/src/services/clienteService.js
@@ -1,5 +1,5 @@
 import { prisma } from "../config/prisma.js";
-import { StatusSerasa } from "../domain/enums.js";
+import { StatusSerasa, StatusVenda } from "../domain/enums.js";
 import { AppError } from "../utils/AppError.js";
 import { ensureEnumValue, parseId, requireFields } from "../utils/validation.js";
 
@@ -7,6 +7,71 @@ const clienteInclude = {
   contaFiado: true,
   vendas: true,
 };
+
+function getClienteInitials(nome) {
+  return nome
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((parte) => parte[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function getClienteStatus(cliente) {
+  if (!cliente.ativo) {
+    return "Inativo";
+  }
+
+  if (cliente.statusSerasa === StatusSerasa.NEGATIVADO) {
+    return "Bloqueado";
+  }
+
+  return "Ativo";
+}
+
+function getClienteDebtStatus(cliente) {
+  const saldoDevedor = Number(cliente.contaFiado?.saldoDevedor ?? 0);
+
+  if (cliente.statusSerasa === StatusSerasa.NEGATIVADO) {
+    return "Bloqueado";
+  }
+
+  if (saldoDevedor > 0) {
+    return "Fiado ativo";
+  }
+
+  return "Em dia";
+}
+
+function getClienteTicket(cliente) {
+  const vendasValidas = cliente.vendas.filter((venda) => venda.status !== StatusVenda.CANCELADA);
+
+  if (vendasValidas.length === 0) {
+    return 0;
+  }
+
+  const valorTotal = vendasValidas.reduce((soma, venda) => soma + Number(venda.valorTotal), 0);
+
+  return Number((valorTotal / vendasValidas.length).toFixed(2));
+}
+
+function serializeCliente(cliente) {
+  if (!cliente) {
+    return cliente;
+  }
+
+  return {
+    ...cliente,
+    name: cliente.nome,
+    phone: cliente.telefone,
+    address: cliente.endereco,
+    initials: getClienteInitials(cliente.nome),
+    status: getClienteStatus(cliente),
+    debtStatus: getClienteDebtStatus(cliente),
+    ticket: getClienteTicket(cliente),
+  };
+}
 
 function buildClienteData(data, { partial = false } = {}) {
   if (!partial) {
@@ -30,23 +95,28 @@ function buildClienteData(data, { partial = false } = {}) {
 }
 
 export async function createCliente(data) {
-  return prisma.cliente.create({
+  const cliente = await prisma.cliente.create({
     data: buildClienteData(data),
     include: clienteInclude,
   });
+
+  return serializeCliente(cliente);
 }
 
 export async function listClientes() {
-  return prisma.cliente.findMany({
+  const clientes = await prisma.cliente.findMany({
+    where: { ativo: true },
     orderBy: { id: "asc" },
     include: clienteInclude,
   });
+
+  return clientes.map(serializeCliente);
 }
 
 export async function getClienteById(idParam) {
   const id = parseId(idParam);
-  const cliente = await prisma.cliente.findUnique({
-    where: { id },
+  const cliente = await prisma.cliente.findFirst({
+    where: { id, ativo: true },
     include: clienteInclude,
   });
 
@@ -54,7 +124,7 @@ export async function getClienteById(idParam) {
     throw new AppError("Cliente nao encontrado.", 404);
   }
 
-  return cliente;
+  return serializeCliente(cliente);
 }
 
 export async function updateCliente(idParam, data) {
@@ -62,11 +132,13 @@ export async function updateCliente(idParam, data) {
 
   await getClienteById(id);
 
-  return prisma.cliente.update({
+  const cliente = await prisma.cliente.update({
     where: { id },
     data: buildClienteData(data, { partial: true }),
     include: clienteInclude,
   });
+
+  return serializeCliente(cliente);
 }
 
 export async function deleteCliente(idParam) {

--- a/apps/api/src/services/produtoService.js
+++ b/apps/api/src/services/produtoService.js
@@ -11,6 +11,22 @@ const produtoInclude = {
   itensVenda: true,
 };
 
+function serializeProduto(produto) {
+  if (!produto) {
+    return produto;
+  }
+
+  return {
+    ...produto,
+    name: produto.nome,
+    category: produto.categoria,
+    sku: produto.codigoBarras,
+    price: Number(produto.precoBase),
+    stock: 0,
+    unit: "un",
+  };
+}
+
 function buildProdutoData(data, { partial = false } = {}) {
   if (!partial) {
     requireFields(data, ["codigoBarras", "nome", "precoBase", "categoria"]);
@@ -32,23 +48,28 @@ function buildProdutoData(data, { partial = false } = {}) {
 }
 
 export async function createProduto(data) {
-  return prisma.produto.create({
+  const produto = await prisma.produto.create({
     data: buildProdutoData(data),
     include: produtoInclude,
   });
+
+  return serializeProduto(produto);
 }
 
 export async function listProdutos() {
-  return prisma.produto.findMany({
+  const produtos = await prisma.produto.findMany({
+    where: { ativo: true },
     orderBy: { id: "asc" },
     include: produtoInclude,
   });
+
+  return produtos.map(serializeProduto);
 }
 
 export async function getProdutoById(idParam) {
   const id = parseId(idParam);
-  const produto = await prisma.produto.findUnique({
-    where: { id },
+  const produto = await prisma.produto.findFirst({
+    where: { id, ativo: true },
     include: produtoInclude,
   });
 
@@ -56,7 +77,7 @@ export async function getProdutoById(idParam) {
     throw new AppError("Produto nao encontrado.", 404);
   }
 
-  return produto;
+  return serializeProduto(produto);
 }
 
 export async function updateProduto(idParam, data) {
@@ -64,11 +85,13 @@ export async function updateProduto(idParam, data) {
 
   await getProdutoById(id);
 
-  return prisma.produto.update({
+  const produto = await prisma.produto.update({
     where: { id },
     data: buildProdutoData(data, { partial: true }),
     include: produtoInclude,
   });
+
+  return serializeProduto(produto);
 }
 
 export async function deleteProduto(idParam) {

--- a/apps/web/src/app/app.config.ts
+++ b/apps/web/src/app/app.config.ts
@@ -1,10 +1,12 @@
 import { ApplicationConfig, LOCALE_ID, provideBrowserGlobalErrorListeners } from "@angular/core";
+import { provideHttpClient } from "@angular/common/http";
 import { provideRouter } from "@angular/router";
 import { routes } from "./app.routes";
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
+    provideHttpClient(),
     provideRouter(routes),
     { provide: LOCALE_ID, useValue: "pt-BR" }
   ]

--- a/apps/web/src/app/core/models.ts
+++ b/apps/web/src/app/core/models.ts
@@ -10,7 +10,7 @@ export interface Client {
   id: number;
   initials: string;
   name: string;
-  email: string;
+  email?: string | null;
   phone: string;
   address: string;
   status: string;

--- a/apps/web/src/app/core/services/clients-api.service.ts
+++ b/apps/web/src/app/core/services/clients-api.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, inject } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { Client } from "../models";
+
+const API_BASE_URL = "http://localhost:3333";
+
+@Injectable({ providedIn: "root" })
+export class ClientsApiService {
+  private readonly http = inject(HttpClient);
+
+  listClients(): Observable<Client[]> {
+    return this.http.get<Client[]>(`${API_BASE_URL}/clientes`);
+  }
+}

--- a/apps/web/src/app/core/services/products-api.service.ts
+++ b/apps/web/src/app/core/services/products-api.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, inject } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { Product } from "../models";
+
+const API_BASE_URL = "http://localhost:3333";
+
+@Injectable({ providedIn: "root" })
+export class ProductsApiService {
+  private readonly http = inject(HttpClient);
+
+  listProducts(): Observable<Product[]> {
+    return this.http.get<Product[]>(`${API_BASE_URL}/produtos`);
+  }
+}

--- a/apps/web/src/app/features/clients/clients.component.css
+++ b/apps/web/src/app/features/clients/clients.component.css
@@ -1,3 +1,42 @@
+.clients-page {
+  position: relative;
+}
+
+.clients-header {
+  align-items: start;
+}
+
+.clients-title {
+  font-size: 1.2rem;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+}
+
+.btn-new-client {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: 0;
+  border-radius: 8px;
+  padding: 1rem 1.2rem;
+  background: #162236;
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 700;
+  box-shadow: 0 10px 20px rgba(22, 34, 54, 0.18);
+}
+
+.btn-new-icon {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  border: 1.5px solid rgba(255, 255, 255, 0.8);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
 .stats-row {
   margin-bottom: 1rem;
 }
@@ -25,6 +64,110 @@
   margin: 0 0 1rem;
 }
 
+.client-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.icon-action {
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+  color: #90a0b8;
+  padding: 0;
+}
+
+.icon-action svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .retry-button {
   margin-top: 1rem;
+}
+
+.client-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(4px);
+}
+
+.client-modal {
+  width: min(100%, 720px);
+  border-radius: 16px;
+  background: #ffffff;
+  border: 1px solid #e5ebf3;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+}
+
+.client-modal-head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.3rem 1.4rem 1rem;
+  border-bottom: 1px solid #eef2f7;
+}
+
+.client-modal-title {
+  color: #162236;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.client-modal-subtitle {
+  margin-top: 0.25rem;
+  color: #8290a6;
+  font-size: 0.88rem;
+}
+
+.modal-close {
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 10px;
+  background: #f3f6fa;
+  color: #5d6d84;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.client-form {
+  display: grid;
+  gap: 1.2rem;
+  padding: 1.25rem 1.4rem 1.4rem;
+}
+
+.client-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.client-form-full {
+  grid-column: 1 / -1;
+}
+
+.client-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.8rem;
+}
+
+@media (max-width: 720px) {
+  .client-form-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/apps/web/src/app/features/clients/clients.component.css
+++ b/apps/web/src/app/features/clients/clients.component.css
@@ -24,3 +24,7 @@
 .search-bar {
   margin: 0 0 1rem;
 }
+
+.retry-button {
+  margin-top: 1rem;
+}

--- a/apps/web/src/app/features/clients/clients.component.html
+++ b/apps/web/src/app/features/clients/clients.component.html
@@ -1,72 +1,152 @@
-<div class="page-header">
-  <div>
-    <div class="page-title">Gestao de clientes</div>
-    <div class="page-subtitle">Gerencie sua base de clientes e controle de credito.</div>
-  </div>
-  <div class="toolbar">
-    <button class="btn-secondary" type="button">Exportar PDF</button>
-    <button class="btn-secondary" type="button">Exportar Excel</button>
-    <button class="btn-primary" type="button">Novo cliente</button>
-  </div>
-</div>
-
-<div class="stats-row">
-  <div class="stat-row-item"><div class="stat-row-label">Total de clientes</div><div class="stat-row-value">{{ totalClients }}</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Clientes ativos</div><div class="stat-row-value green">{{ activeClients }}</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Bloqueados (fiado)</div><div class="stat-row-value red">{{ blockedClients }}</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Ticket medio</div><div class="stat-row-value">{{ formatCurrency(averageTicket) }}</div></div>
-</div>
-
-<input class="search-bar" type="text" placeholder="Buscar clientes por nome ou telefone..." [(ngModel)]="query" />
-
-<div class="table-panel">
-  <div *ngIf="isLoading" class="empty-state">Carregando clientes da API...</div>
-
-  <div *ngIf="!isLoading && errorMessage" class="empty-state">
-    <div>{{ errorMessage }}</div>
-    <button class="btn-secondary retry-button" type="button" (click)="retry()">Tentar novamente</button>
-  </div>
-
-  <table>
-    <thead *ngIf="!isLoading && !errorMessage">
-      <tr>
-        <th>Cliente</th>
-        <th>Telefone</th>
-        <th>Endereco</th>
-        <th>Status</th>
-        <th>Fiado</th>
-        <th>Ticket medio</th>
-      </tr>
-    </thead>
-    <tbody *ngIf="!isLoading && !errorMessage">
-      <tr *ngFor="let client of filteredClients">
-        <td>
-          <div class="client-name">{{ client.name }}</div>
-          <div class="client-time">{{ client.email || "Sem e-mail cadastrado" }}</div>
-        </td>
-        <td>{{ client.phone }}</td>
-        <td>{{ client.address }}</td>
-        <td><pf-status-badge [text]="client.status" /></td>
-        <td><pf-status-badge [text]="client.debtStatus" /></td>
-        <td>{{ formatCurrency(client.ticket) }}</td>
-      </tr>
-      <tr *ngIf="filteredClients.length === 0">
-        <td colspan="6" class="empty-state">Nenhum cliente encontrado.</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <div *ngIf="!isLoading && !errorMessage" class="table-footer">
-    <span>Exibindo {{ filteredClients.length }} de {{ clients.length }} clientes</span>
-    <div class="pagination">
-      <button class="page-btn active" type="button">1</button>
-      <button class="page-btn" type="button">2</button>
-      <button class="page-btn" type="button">3</button>
+<div class="clients-page">
+  <div class="page-header clients-header">
+    <div>
+      <div class="page-title clients-title">Gestao de clientes</div>
+      <div class="page-subtitle">Gerencie sua base de clientes e controle de credito.</div>
+    </div>
+    <div class="toolbar">
+      <button class="btn-secondary" type="button">Exportar PDF</button>
+      <button class="btn-secondary" type="button">Exportar Excel</button>
+      <button class="btn-new-client" type="button" (click)="openCreateModal()">
+        <span class="btn-new-icon">+</span>
+        <span>Novo cliente</span>
+      </button>
     </div>
   </div>
 
-  <div *ngIf="!isLoading && isUsingFallbackData" class="table-footer fallback-note">
-    <span>{{ fallbackMessage }}</span>
-    <button class="btn-secondary" type="button" (click)="retry()">Tentar API novamente</button>
+  <div class="stats-row">
+    <div class="stat-row-item"><div class="stat-row-label">Total de clientes</div><div class="stat-row-value">{{ totalClients }}</div></div>
+    <div class="stat-row-item"><div class="stat-row-label">Clientes ativos</div><div class="stat-row-value green">{{ activeClients }}</div></div>
+    <div class="stat-row-item"><div class="stat-row-label">Bloqueados (fiado)</div><div class="stat-row-value red">{{ blockedClients }}</div></div>
+    <div class="stat-row-item"><div class="stat-row-label">Ticket medio</div><div class="stat-row-value">{{ formatCurrency(averageTicket) }}</div></div>
+  </div>
+
+  <input class="search-bar" type="text" placeholder="Buscar clientes por nome ou telefone..." [(ngModel)]="query" />
+
+  <div class="table-panel">
+    <div *ngIf="isLoading" class="empty-state">Carregando clientes da API...</div>
+
+    <div *ngIf="!isLoading && errorMessage" class="empty-state">
+      <div>{{ errorMessage }}</div>
+      <button class="btn-secondary retry-button" type="button" (click)="retry()">Tentar novamente</button>
+    </div>
+
+    <table>
+      <thead *ngIf="!isLoading && !errorMessage">
+        <tr>
+          <th>Cliente</th>
+          <th>Telefone</th>
+          <th>Endereco</th>
+          <th>Status</th>
+          <th>Fiado</th>
+          <th>Ticket medio</th>
+          <th>Acoes</th>
+        </tr>
+      </thead>
+      <tbody *ngIf="!isLoading && !errorMessage">
+        <tr *ngFor="let client of filteredClients">
+          <td>
+            <div class="client-name">{{ client.name }}</div>
+            <div class="client-time">{{ client.email || "Sem e-mail cadastrado" }}</div>
+          </td>
+          <td>{{ client.phone }}</td>
+          <td>{{ client.address }}</td>
+          <td><pf-status-badge [text]="client.status" /></td>
+          <td><pf-status-badge [text]="client.debtStatus" /></td>
+          <td>{{ formatCurrency(client.ticket) }}</td>
+          <td>
+            <div class="client-actions">
+              <button class="icon-action" type="button" aria-label="Editar cliente" (click)="openEditModal(client)">
+                <svg viewBox="0 0 24 24" fill="none">
+                  <path d="M4 20h4l10-10-4-4L4 16v4ZM13 7l4 4" />
+                </svg>
+              </button>
+              <button class="icon-action" type="button" aria-label="Excluir cliente" (click)="deleteClient(client.id)">
+                <svg viewBox="0 0 24 24" fill="none">
+                  <path d="M5 7h14M9 7V4h6v3M8 10v7M12 10v7M16 10v7M7 7l1 13h8l1-13" />
+                </svg>
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr *ngIf="filteredClients.length === 0">
+          <td colspan="7" class="empty-state">Nenhum cliente encontrado.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div *ngIf="!isLoading && !errorMessage" class="table-footer">
+      <span>Exibindo {{ filteredClients.length }} de {{ clients.length }} clientes</span>
+      <div class="pagination">
+        <button class="page-btn active" type="button">1</button>
+        <button class="page-btn" type="button">2</button>
+        <button class="page-btn" type="button">3</button>
+      </div>
+    </div>
+
+    <div *ngIf="!isLoading && isUsingFallbackData" class="table-footer fallback-note">
+      <span>{{ fallbackMessage }}</span>
+      <button class="btn-secondary" type="button" (click)="retry()">Tentar API novamente</button>
+    </div>
+  </div>
+
+  <div *ngIf="isModalOpen" class="client-modal-backdrop" (click)="closeModal()">
+    <div class="client-modal" (click)="$event.stopPropagation()">
+      <div class="client-modal-head">
+        <div>
+          <div class="client-modal-title">{{ modalMode === 'edit' ? 'Editar cliente' : 'Novo cliente' }}</div>
+          <div class="client-modal-subtitle">Os dados serao salvos localmente nesta tela enquanto a gravacao no backend nao estiver ativa.</div>
+        </div>
+        <button class="modal-close" type="button" (click)="closeModal()">×</button>
+      </div>
+
+      <form class="client-form" (ngSubmit)="submitForm()">
+        <div class="client-form-grid">
+          <div class="form-group">
+            <label class="form-label">Nome</label>
+            <input class="form-input" name="name" [(ngModel)]="form.name" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">E-mail</label>
+            <input class="form-input" name="email" type="email" [(ngModel)]="form.email" />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Telefone</label>
+            <input class="form-input" name="phone" [(ngModel)]="form.phone" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Endereco</label>
+            <input class="form-input" name="address" [(ngModel)]="form.address" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Status</label>
+            <select class="form-select" name="status" [(ngModel)]="form.status">
+              <option *ngFor="let item of statusOptions" [value]="item">{{ item }}</option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Fiado</label>
+            <select class="form-select" name="debtStatus" [(ngModel)]="form.debtStatus">
+              <option *ngFor="let item of debtStatusOptions" [value]="item">{{ item }}</option>
+            </select>
+          </div>
+
+          <div class="form-group client-form-full">
+            <label class="form-label">Ticket medio</label>
+            <input class="form-input" name="ticket" type="number" min="0" step="0.01" [(ngModel)]="form.ticket" required />
+          </div>
+        </div>
+
+        <div class="client-modal-actions">
+          <button class="btn-secondary" type="button" (click)="closeModal()">Cancelar</button>
+          <button class="btn-primary" type="submit">{{ modalMode === 'edit' ? 'Salvar alteracoes' : 'Cadastrar cliente' }}</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>

--- a/apps/web/src/app/features/clients/clients.component.html
+++ b/apps/web/src/app/features/clients/clients.component.html
@@ -11,17 +11,24 @@
 </div>
 
 <div class="stats-row">
-  <div class="stat-row-item"><div class="stat-row-label">Total de clientes</div><div class="stat-row-value">1.284</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Clientes ativos</div><div class="stat-row-value green">1.120</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Bloqueados (fiado)</div><div class="stat-row-value red">164</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Ticket medio</div><div class="stat-row-value">{{ formatCurrency(452) }}</div></div>
+  <div class="stat-row-item"><div class="stat-row-label">Total de clientes</div><div class="stat-row-value">{{ totalClients }}</div></div>
+  <div class="stat-row-item"><div class="stat-row-label">Clientes ativos</div><div class="stat-row-value green">{{ activeClients }}</div></div>
+  <div class="stat-row-item"><div class="stat-row-label">Bloqueados (fiado)</div><div class="stat-row-value red">{{ blockedClients }}</div></div>
+  <div class="stat-row-item"><div class="stat-row-label">Ticket medio</div><div class="stat-row-value">{{ formatCurrency(averageTicket) }}</div></div>
 </div>
 
 <input class="search-bar" type="text" placeholder="Buscar clientes por nome ou telefone..." [(ngModel)]="query" />
 
 <div class="table-panel">
+  <div *ngIf="isLoading" class="empty-state">Carregando clientes da API...</div>
+
+  <div *ngIf="!isLoading && errorMessage" class="empty-state">
+    <div>{{ errorMessage }}</div>
+    <button class="btn-secondary retry-button" type="button" (click)="retry()">Tentar novamente</button>
+  </div>
+
   <table>
-    <thead>
+    <thead *ngIf="!isLoading && !errorMessage">
       <tr>
         <th>Cliente</th>
         <th>Telefone</th>
@@ -31,11 +38,11 @@
         <th>Ticket medio</th>
       </tr>
     </thead>
-    <tbody>
+    <tbody *ngIf="!isLoading && !errorMessage">
       <tr *ngFor="let client of filteredClients">
         <td>
           <div class="client-name">{{ client.name }}</div>
-          <div class="client-time">{{ client.email }}</div>
+          <div class="client-time">{{ client.email || "Sem e-mail cadastrado" }}</div>
         </td>
         <td>{{ client.phone }}</td>
         <td>{{ client.address }}</td>
@@ -43,15 +50,23 @@
         <td><pf-status-badge [text]="client.debtStatus" /></td>
         <td>{{ formatCurrency(client.ticket) }}</td>
       </tr>
+      <tr *ngIf="filteredClients.length === 0">
+        <td colspan="6" class="empty-state">Nenhum cliente encontrado.</td>
+      </tr>
     </tbody>
   </table>
 
-  <div class="table-footer">
-    <span>Exibindo {{ filteredClients.length }} de {{ clients.length }} clientes simulados</span>
+  <div *ngIf="!isLoading && !errorMessage" class="table-footer">
+    <span>Exibindo {{ filteredClients.length }} de {{ clients.length }} clientes</span>
     <div class="pagination">
       <button class="page-btn active" type="button">1</button>
       <button class="page-btn" type="button">2</button>
       <button class="page-btn" type="button">3</button>
     </div>
+  </div>
+
+  <div *ngIf="!isLoading && isUsingFallbackData" class="table-footer fallback-note">
+    <span>{{ fallbackMessage }}</span>
+    <button class="btn-secondary" type="button" (click)="retry()">Tentar API novamente</button>
   </div>
 </div>

--- a/apps/web/src/app/features/clients/clients.component.ts
+++ b/apps/web/src/app/features/clients/clients.component.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
-import { clients } from "../../core/mock-data";
+import { Client } from "../../core/models";
+import { clients as mockClients } from "../../core/mock-data";
+import { ClientsApiService } from "../../core/services/clients-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 import { formatCurrency } from "../../core/utils/format";
 
@@ -12,15 +14,73 @@ import { formatCurrency } from "../../core/utils/format";
   templateUrl: "./clients.component.html",
   styleUrl: "./clients.component.css"
 })
-export class ClientsComponent {
+export class ClientsComponent implements OnInit {
   query = "";
-  readonly clients = clients;
+  clients: Client[] = [];
+  isLoading = true;
+  errorMessage = "";
+  isUsingFallbackData = false;
+  fallbackMessage = "";
   readonly formatCurrency = formatCurrency;
+
+  constructor(private readonly clientsApiService: ClientsApiService) {}
+
+  ngOnInit(): void {
+    this.loadClients();
+  }
 
   get filteredClients() {
     const normalized = this.query.toLowerCase();
     return this.clients.filter((client) =>
-      [client.name, client.email, client.phone].some((value) => value.toLowerCase().includes(normalized))
+      [client.name, client.email ?? "", client.phone].some((value) =>
+        value.toLowerCase().includes(normalized),
+      )
     );
+  }
+
+  get totalClients(): number {
+    return this.clients.length;
+  }
+
+  get activeClients(): number {
+    return this.clients.filter((client) => client.status === "Ativo").length;
+  }
+
+  get blockedClients(): number {
+    return this.clients.filter((client) => client.status === "Bloqueado").length;
+  }
+
+  get averageTicket(): number {
+    if (!this.clients.length) {
+      return 0;
+    }
+
+    const total = this.clients.reduce((sum, client) => sum + client.ticket, 0);
+
+    return Number((total / this.clients.length).toFixed(2));
+  }
+
+  retry(): void {
+    this.loadClients();
+  }
+
+  private loadClients(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.isUsingFallbackData = false;
+    this.fallbackMessage = "";
+
+    this.clientsApiService.listClients().subscribe({
+      next: (clients) => {
+        this.clients = clients;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.clients = mockClients;
+        this.isUsingFallbackData = true;
+        this.fallbackMessage = "API de clientes indisponivel no momento. Exibindo dados locais para continuarmos a validacao da tela.";
+        this.isLoading = false;
+      },
+    });
   }
 }

--- a/apps/web/src/app/features/clients/clients.component.ts
+++ b/apps/web/src/app/features/clients/clients.component.ts
@@ -7,6 +7,17 @@ import { ClientsApiService } from "../../core/services/clients-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 import { formatCurrency } from "../../core/utils/format";
 
+type ClientForm = {
+  id: number | null;
+  name: string;
+  email: string;
+  phone: string;
+  address: string;
+  status: string;
+  debtStatus: string;
+  ticket: number;
+};
+
 @Component({
   selector: "pf-clients",
   standalone: true,
@@ -21,7 +32,12 @@ export class ClientsComponent implements OnInit {
   errorMessage = "";
   isUsingFallbackData = false;
   fallbackMessage = "";
+  isModalOpen = false;
+  modalMode: "create" | "edit" = "create";
   readonly formatCurrency = formatCurrency;
+  readonly statusOptions = ["Ativo", "Bloqueado", "VIP", "Inativo"];
+  readonly debtStatusOptions = ["Em dia", "Fiado ativo", "Bloqueado", "Critico", "Acompanhando"];
+  form: ClientForm = this.getEmptyForm();
 
   constructor(private readonly clientsApiService: ClientsApiService) {}
 
@@ -64,6 +80,64 @@ export class ClientsComponent implements OnInit {
     this.loadClients();
   }
 
+  openCreateModal(): void {
+    this.modalMode = "create";
+    this.form = this.getEmptyForm();
+    this.isModalOpen = true;
+  }
+
+  openEditModal(client: Client): void {
+    this.modalMode = "edit";
+    this.form = {
+      id: client.id,
+      name: client.name,
+      email: client.email ?? "",
+      phone: client.phone,
+      address: client.address,
+      status: client.status,
+      debtStatus: client.debtStatus,
+      ticket: client.ticket,
+    };
+    this.isModalOpen = true;
+  }
+
+  closeModal(): void {
+    this.isModalOpen = false;
+    this.form = this.getEmptyForm();
+  }
+
+  submitForm(): void {
+    const normalizedClient: Client = {
+      id: this.form.id ?? this.generateNextId(),
+      initials: this.getInitials(this.form.name),
+      name: this.form.name.trim(),
+      email: this.form.email.trim() || null,
+      phone: this.form.phone.trim(),
+      address: this.form.address.trim(),
+      status: this.form.status,
+      debtStatus: this.form.debtStatus,
+      ticket: Number(this.form.ticket),
+    };
+
+    if (!normalizedClient.name || !normalizedClient.phone || !normalizedClient.address) {
+      return;
+    }
+
+    if (this.modalMode === "edit" && this.form.id !== null) {
+      this.clients = this.clients.map((client) =>
+        client.id === this.form.id ? normalizedClient : client,
+      );
+    } else {
+      this.clients = [normalizedClient, ...this.clients];
+    }
+
+    this.closeModal();
+  }
+
+  deleteClient(clientId: number): void {
+    this.clients = this.clients.filter((client) => client.id !== clientId);
+  }
+
   private loadClients(): void {
     this.isLoading = true;
     this.errorMessage = "";
@@ -82,5 +156,32 @@ export class ClientsComponent implements OnInit {
         this.isLoading = false;
       },
     });
+  }
+
+  private getEmptyForm(): ClientForm {
+    return {
+      id: null,
+      name: "",
+      email: "",
+      phone: "",
+      address: "",
+      status: "Ativo",
+      debtStatus: "Em dia",
+      ticket: 0,
+    };
+  }
+
+  private getInitials(name: string): string {
+    return name
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase() ?? "")
+      .join("");
+  }
+
+  private generateNextId(): number {
+    return this.clients.reduce((max, client) => Math.max(max, client.id), 0) + 1;
   }
 }

--- a/apps/web/src/app/features/dashboard/dashboard.component.css
+++ b/apps/web/src/app/features/dashboard/dashboard.component.css
@@ -101,6 +101,9 @@
 .performance-panel {
   padding: 1.8rem 1.9rem 1.45rem;
   border-radius: 14px;
+  background:
+    radial-gradient(circle at top right, rgba(37, 99, 235, 0.08), transparent 26%),
+    linear-gradient(180deg, #ffffff, #f8fbff);
 }
 
 .performance-head {
@@ -108,7 +111,7 @@
   align-items: start;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1.25rem;
 }
 
 .performance-title,
@@ -130,7 +133,7 @@
   background: transparent;
   color: #4f5d71;
   padding: 0.45rem 0.85rem;
-  border-radius: 6px;
+  border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 800;
   letter-spacing: 0.08em;
@@ -139,25 +142,82 @@
 .period-btn.active {
   background: #f1f4f8;
   color: #1d2738;
+  box-shadow: inset 0 0 0 1px #d9e3ef;
+}
+
+.performance-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-bottom: 1.3rem;
+}
+
+.performance-kpi {
+  display: grid;
+  gap: 0.3rem;
+  padding: 0.95rem 1rem;
+  border-radius: 14px;
+  background: rgba(241, 245, 249, 0.9);
+  border: 1px solid #e2e8f0;
+}
+
+.performance-kpi strong {
+  color: #122033;
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.performance-kpi-accent {
+  background: linear-gradient(135deg, #e7f8ef, #f4fbf7);
+  border-color: #cdebd9;
+}
+
+.performance-kpi-label {
+  color: #64748b;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .dashboard-chart {
-  min-height: 300px;
-  gap: 0.55rem;
-  padding-top: 0.5rem;
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  align-items: end;
+  gap: 0.9rem;
+  min-height: 320px;
+  padding: 1.2rem 0.2rem 0;
   overflow: visible;
+}
+
+.chart-grid {
+  position: absolute;
+  inset: 0 0 1.45rem 0;
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  pointer-events: none;
+}
+
+.chart-grid span {
+  border-top: 1px dashed #dbe5f0;
 }
 
 .bar-wrap {
   position: relative;
+  z-index: 1;
   min-width: 0;
-  flex: 1 1 0;
-  gap: 0.8rem;
+  height: 100%;
+  display: grid;
+  grid-template-rows: auto auto 1fr auto;
+  align-items: end;
+  justify-items: center;
+  gap: 0.55rem;
 }
 
 .bar-tooltip {
   position: absolute;
-  top: -2.1rem;
+  top: -2.25rem;
   left: 50%;
   transform: translateX(-50%) translateY(4px);
   opacity: 0;
@@ -177,22 +237,31 @@
   transform: translateX(-50%) translateY(0);
 }
 
+.bar-value {
+  color: #8a97ab;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
 .bar {
   width: 100%;
-  max-width: 72px;
-  border-radius: 6px 6px 0 0;
-  background: #e7edf5;
+  max-width: 56px;
+  align-self: end;
+  border-radius: 18px 18px 8px 8px;
+  background: linear-gradient(180deg, #dbe5f2, #cfd9e7);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
 }
 
 .bar.active {
-  background: #0e7a51;
+  background: linear-gradient(180deg, #21b47a, #0e7a51);
+  box-shadow: 0 14px 24px rgba(14, 122, 81, 0.18);
 }
 
 .bar-label {
-  color: #454f5f;
-  font-size: 0.74rem;
-  font-weight: 800;
-  letter-spacing: 0.04em;
+  color: #334155;
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
 }
 
 .dashboard-alerts {
@@ -283,7 +352,7 @@
   margin-top: 1.55rem;
   width: 100%;
   border: 0;
-  border-radius: 4px;
+  border-radius: 10px;
   padding: 1rem;
   background: #1dbb89;
   color: #051a1e;
@@ -396,10 +465,40 @@
   .dashboard-main {
     grid-template-columns: 1fr;
   }
+
+  .performance-summary {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 720px) {
   .dashboard-stats {
     grid-template-columns: 1fr;
+  }
+
+  .performance-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .period-switch {
+    justify-content: flex-start;
+  }
+
+  .dashboard-chart {
+    gap: 0.45rem;
+    min-height: 260px;
+  }
+
+  .bar {
+    max-width: 36px;
+  }
+
+  .bar-value {
+    font-size: 0.65rem;
+  }
+
+  .bar-label {
+    font-size: 0.7rem;
   }
 }

--- a/apps/web/src/app/features/dashboard/dashboard.component.html
+++ b/apps/web/src/app/features/dashboard/dashboard.component.html
@@ -10,12 +10,12 @@
         </div>
       </div>
       <div class="stat-value">{{ formatCurrency(overview.totalSoldToday) }}</div>
-      <div class="stat-sub"><span class="stat-up">↗ +12%</span> vs. ontem</div>
+      <div class="stat-sub"><span class="stat-up">+12%</span> vs. ontem</div>
     </article>
 
     <article class="stat-card">
       <div class="stat-top">
-        <div class="stat-label">Nº DE VENDAS</div>
+        <div class="stat-label">NUMERO DE VENDAS</div>
         <div class="stat-icon stat-icon-slate">
           <svg viewBox="0 0 24 24" fill="none">
             <path d="M4 6h2l2.2 9h8.7l2.1-6H9M10 19a1 1 0 1 0 0 2 1 1 0 0 0 0-2ZM17 19a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z" />
@@ -28,7 +28,7 @@
 
     <article class="stat-card">
       <div class="stat-top">
-        <div class="stat-label">TICKET MÉDIO</div>
+        <div class="stat-label">TICKET MEDIO</div>
         <div class="stat-icon stat-icon-slate">
           <svg viewBox="0 0 24 24" fill="none">
             <path d="M6 4h12v16H6zM9 15v-3M12 15V9M15 15v-5" />
@@ -36,7 +36,7 @@
         </div>
       </div>
       <div class="stat-value">{{ formatCurrency(overview.averageTicket) }}</div>
-      <div class="stat-sub">Por transação</div>
+      <div class="stat-sub">Por transacao</div>
     </article>
 
     <article class="stat-card stat-card-warn">
@@ -49,7 +49,7 @@
         </div>
       </div>
       <div class="stat-value">{{ overview.debtClients }}</div>
-      <div class="stat-sub stat-danger">△ Atenção necessária</div>
+      <div class="stat-sub stat-danger">Atencao necessaria</div>
     </article>
   </div>
 
@@ -63,11 +63,33 @@
 
         <div class="period-switch">
           <button class="period-btn" [class.active]="selectedPeriod === 'semana'" type="button" (click)="setPeriod('semana')">SEMANA</button>
-          <button class="period-btn" [class.active]="selectedPeriod === 'mes'" type="button" (click)="setPeriod('mes')">MÊS</button>
+          <button class="period-btn" [class.active]="selectedPeriod === 'mes'" type="button" (click)="setPeriod('mes')">MES</button>
+        </div>
+      </div>
+
+      <div class="performance-summary">
+        <div class="performance-kpi">
+          <span class="performance-kpi-label">Total no periodo</span>
+          <strong>{{ formatCurrency(chartTotal) }}</strong>
+        </div>
+        <div class="performance-kpi">
+          <span class="performance-kpi-label">Media por {{ selectedPeriod === 'semana' ? 'dia' : 'semana' }}</span>
+          <strong>{{ formatCurrency(chartAverage) }}</strong>
+        </div>
+        <div class="performance-kpi performance-kpi-accent">
+          <span class="performance-kpi-label">Melhor {{ selectedPeriod === 'semana' ? 'dia' : 'semana' }}</span>
+          <strong>{{ chartPeak.day }} · {{ formatCurrency(chartPeak.value) }}</strong>
         </div>
       </div>
 
       <div class="bar-chart dashboard-chart">
+        <div class="chart-grid" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+
         <div
           *ngFor="let item of chartData; let index = index"
           class="bar-wrap"
@@ -77,6 +99,7 @@
           <div class="bar-tooltip" [class.visible]="hoveredIndex === index">
             {{ formatCurrency(item.value) }}
           </div>
+          <div class="bar-value">{{ formatCurrency(item.value) }}</div>
           <div
             class="bar"
             [class.active]="selectedPeriod === 'semana' ? item.day === 'Sab' : index === 3"
@@ -117,8 +140,8 @@
 
   <section class="table-panel latest-sales-panel">
     <div class="section-header latest-sales-head">
-      <div class="section-title latest-sales-title">ÚLTIMAS VENDAS</div>
-      <a class="history-link" routerLink="/historico">VER HISTÓRICO COMPLETO</a>
+      <div class="section-title latest-sales-title">ULTIMAS VENDAS</div>
+      <a class="history-link" routerLink="/historico">VER HISTORICO COMPLETO</a>
     </div>
 
     <table class="latest-sales-table">
@@ -144,7 +167,7 @@
             </div>
           </td>
           <td class="product-main">{{ sale.mainProduct }}</td>
-          <td><pf-status-badge [text]="sale.status === 'Pendente' ? 'FIADO' : 'CONCLUÍDA'" [tone]="sale.status === 'Pendente' ? 'warning' : 'success'" /></td>
+          <td><pf-status-badge [text]="sale.status === 'Pendente' ? 'FIADO' : 'CONCLUIDA'" [tone]="sale.status === 'Pendente' ? 'warning' : 'success'" /></td>
           <td class="sale-value">{{ formatCurrency(sale.value) }}</td>
         </tr>
       </tbody>

--- a/apps/web/src/app/features/dashboard/dashboard.component.ts
+++ b/apps/web/src/app/features/dashboard/dashboard.component.ts
@@ -40,6 +40,24 @@ export class DashboardComponent {
       : "Vendas consolidadas nas ultimas 4 semanas";
   }
 
+  get chartTotal(): number {
+    return this.chartData.reduce((sum, item) => sum + item.value, 0);
+  }
+
+  get chartAverage(): number {
+    if (!this.chartData.length) {
+      return 0;
+    }
+
+    return Number((this.chartTotal / this.chartData.length).toFixed(2));
+  }
+
+  get chartPeak() {
+    return this.chartData.reduce((highest, current) =>
+      current.value > highest.value ? current : highest,
+    );
+  }
+
   setPeriod(period: "semana" | "mes"): void {
     this.selectedPeriod = period;
     this.hoveredIndex = null;
@@ -51,8 +69,8 @@ export class DashboardComponent {
 
   getBarHeight(value: number): number {
     const max = Math.max(...this.chartData.map((item) => item.value));
-    const normalized = (value / max) * 255;
-    return normalized < 64 ? 64 : normalized;
+    const normalized = (value / max) * 220;
+    return normalized < 72 ? 72 : normalized;
   }
 
   getInitials(name: string): string {

--- a/apps/web/src/app/features/products/products.component.css
+++ b/apps/web/src/app/features/products/products.component.css
@@ -236,25 +236,13 @@
   padding: 0;
 }
 
-.icon-action svg,
-.floating-stock-btn svg {
+.icon-action svg {
   width: 18px;
   height: 18px;
   stroke: currentColor;
   stroke-width: 1.9;
   stroke-linecap: round;
   stroke-linejoin: round;
-}
-
-.product-stock {
-  color: #9dadc2;
-  font-size: 0.72rem;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.product-stock.low {
-  color: #d81919;
 }
 
 .products-summary {
@@ -265,6 +253,18 @@
   border-radius: 14px;
   background: #edf2f7;
   overflow: hidden;
+}
+
+.products-fallback-note {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
+  border-radius: 12px;
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
+  color: #9a3412;
 }
 
 .summary-item {
@@ -292,21 +292,6 @@
 
 .summary-value-green {
   color: #0e8a5b;
-}
-
-.floating-stock-btn {
-  position: absolute;
-  right: 0;
-  bottom: -2px;
-  width: 42px;
-  height: 42px;
-  display: grid;
-  place-items: center;
-  border: 0;
-  border-radius: 10px;
-  background: #0faa78;
-  color: #ffffff;
-  box-shadow: 0 10px 18px rgba(15, 170, 120, 0.2);
 }
 
 .product-modal-backdrop {

--- a/apps/web/src/app/features/products/products.component.html
+++ b/apps/web/src/app/features/products/products.component.html
@@ -1,8 +1,8 @@
 <div class="products-page">
   <div class="page-header products-header">
     <div>
-      <div class="page-title products-title">Gestão de Produtos</div>
-      <div class="page-subtitle">Gerencie seu catálogo, estoque e precificação em tempo real.</div>
+      <div class="page-title products-title">Gestao de Produtos</div>
+      <div class="page-subtitle">Gerencie seu catalogo e precificacao em tempo real.</div>
     </div>
 
     <button class="btn-new-product" type="button" (click)="openCreateModal()">
@@ -28,13 +28,19 @@
       <span class="sort-label">ORDENAR POR:</span>
       <select class="sort-select" [(ngModel)]="sortBy">
         <option value="recentes">Mais Recentes</option>
-        <option value="preco">Menor Preço</option>
-        <option value="estoque">Menor Estoque</option>
+        <option value="preco">Menor Preco</option>
       </select>
     </div>
   </div>
 
   <div class="products-grid">
+    <div *ngIf="isLoading" class="empty-state">Carregando produtos da API...</div>
+
+    <div *ngIf="!isLoading && errorMessage" class="empty-state">
+      <div>{{ errorMessage }}</div>
+      <button class="btn-secondary" type="button" (click)="retry()">Tentar novamente</button>
+    </div>
+
     <article *ngFor="let product of filteredProducts" class="product-card">
       <div class="product-hero" [ngClass]="getProductVisual(product.name)">
         <span class="product-category-badge">{{ product.category }}</span>
@@ -62,46 +68,43 @@
               </svg>
             </button>
           </div>
-
-          <div class="product-stock" [class.low]="product.stock < 10">Estoque: {{ product.stock }} {{ product.unit }}</div>
         </div>
       </div>
     </article>
   </div>
 
+  <div *ngIf="!isLoading && isUsingFallbackData" class="products-fallback-note">
+    <span>{{ fallbackMessage }}</span>
+    <button class="btn-secondary" type="button" (click)="retry()">Tentar API novamente</button>
+  </div>
+
   <div class="products-summary">
-    <div class="summary-item">
-      <div class="summary-label">TOTAL EM ESTOQUE</div>
-      <div class="summary-value">{{ formatCurrency(totalInventoryValue) }}</div>
-    </div>
     <div class="summary-item">
       <div class="summary-label">PRODUTOS ATIVOS</div>
       <div class="summary-value">{{ activeProductsCount }}</div>
     </div>
     <div class="summary-item">
-      <div class="summary-label">ITENS S/ MOVIMENTAÇÃO</div>
-      <div class="summary-value">{{ staleProductsCount }}</div>
+      <div class="summary-label">CATEGORIAS</div>
+      <div class="summary-value">{{ categoriesCount }}</div>
     </div>
     <div class="summary-item">
-      <div class="summary-label">GIRO DE ESTOQUE</div>
-      <div class="summary-value summary-value-green">{{ inventoryTurnover }}%</div>
+      <div class="summary-label">COM CATEGORIA</div>
+      <div class="summary-value">{{ categorizedProductsCount }}</div>
+    </div>
+    <div class="summary-item">
+      <div class="summary-label">PRECO MEDIO</div>
+      <div class="summary-value summary-value-green">{{ formatCurrency(averagePrice) }}</div>
     </div>
   </div>
-
-  <button class="floating-stock-btn" type="button" aria-label="Atalho de estoque">
-    <svg viewBox="0 0 24 24" fill="none">
-      <path d="M4 7h16M6 7v10M18 7v10M8 11h8M8 15h8M4 19h16" />
-    </svg>
-  </button>
 
   <div *ngIf="isModalOpen" class="product-modal-backdrop" (click)="closeModal()">
     <div class="product-modal" (click)="$event.stopPropagation()">
       <div class="product-modal-head">
         <div>
           <div class="product-modal-title">{{ modalMode === 'edit' ? 'Editar Produto' : 'Novo Produto' }}</div>
-          <div class="product-modal-subtitle">Os dados serão salvos localmente neste navegador.</div>
+          <div class="product-modal-subtitle">Os dados serao salvos localmente neste navegador.</div>
         </div>
-        <button class="modal-close" type="button" (click)="closeModal()">×</button>
+        <button class="modal-close" type="button" (click)="closeModal()">x</button>
       </div>
 
       <form class="product-form" (ngSubmit)="submitForm()">
@@ -124,24 +127,14 @@
           </div>
 
           <div class="form-group">
-            <label class="form-label">Unidade</label>
-            <input class="form-input" name="unit" [(ngModel)]="form.unit" required />
-          </div>
-
-          <div class="form-group">
-            <label class="form-label">Estoque</label>
-            <input class="form-input" name="stock" type="number" min="0" [(ngModel)]="form.stock" required />
-          </div>
-
-          <div class="form-group">
-            <label class="form-label">Preço</label>
+            <label class="form-label">Preco</label>
             <input class="form-input" name="price" type="number" min="0" step="0.01" [(ngModel)]="form.price" required />
           </div>
         </div>
 
         <div class="product-modal-actions">
           <button class="btn-secondary" type="button" (click)="closeModal()">Cancelar</button>
-          <button class="btn-primary" type="submit">{{ modalMode === 'edit' ? 'Salvar alterações' : 'Cadastrar produto' }}</button>
+          <button class="btn-primary" type="submit">{{ modalMode === 'edit' ? 'Salvar alteracoes' : 'Cadastrar produto' }}</button>
         </div>
       </form>
     </div>

--- a/apps/web/src/app/features/products/products.component.ts
+++ b/apps/web/src/app/features/products/products.component.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { Product } from "../../core/models";
+import { products as mockProducts } from "../../core/mock-data";
+import { ProductsApiService } from "../../core/services/products-api.service";
 import { StorageService } from "../../core/services/storage.service";
 import { formatCurrency } from "../../core/utils/format";
 
@@ -10,8 +12,6 @@ type ProductForm = {
   name: string;
   category: string;
   sku: string;
-  stock: number;
-  unit: string;
   price: number;
 };
 
@@ -22,19 +22,28 @@ type ProductForm = {
   templateUrl: "./products.component.html",
   styleUrl: "./products.component.css"
 })
-export class ProductsComponent {
+export class ProductsComponent implements OnInit {
   category = "Todos";
   sortBy = "recentes";
   isModalOpen = false;
   modalMode: "create" | "edit" = "create";
   products: Product[] = [];
+  isLoading = true;
+  errorMessage = "";
+  isUsingFallbackData = false;
+  fallbackMessage = "";
   readonly categories = ["Todos", "Paes", "Frios", "Bebidas", "Mercearia"];
   readonly productCategories = ["Paes", "Frios", "Bebidas", "Mercearia"];
   readonly formatCurrency = formatCurrency;
 
   form: ProductForm = this.getEmptyForm();
 
-  constructor(private readonly storageService: StorageService) {
+  constructor(
+    private readonly storageService: StorageService,
+    private readonly productsApiService: ProductsApiService,
+  ) {}
+
+  ngOnInit(): void {
     this.loadProducts();
   }
 
@@ -45,32 +54,33 @@ export class ProductsComponent {
       return [...filtered].sort((a, b) => a.price - b.price);
     }
 
-    if (this.sortBy === "estoque") {
-      return [...filtered].sort((a, b) => a.stock - b.stock);
-    }
-
     return [...filtered].sort((a, b) => b.id - a.id);
   }
 
-  get totalInventoryValue(): number {
-    return this.products.reduce((sum, product) => sum + product.price * product.stock, 0);
+  get averagePrice(): number {
+    if (!this.products.length) {
+      return 0;
+    }
+
+    const total = this.products.reduce((sum, product) => sum + product.price, 0);
+
+    return Number((total / this.products.length).toFixed(2));
   }
 
   get activeProductsCount(): number {
     return this.products.length;
   }
 
-  get staleProductsCount(): number {
-    return this.products.filter((product) => product.stock <= 12).length;
+  get categorizedProductsCount(): number {
+    return this.products.filter((product) => product.category.trim().length > 0).length;
   }
 
-  get inventoryTurnover(): number {
+  get categoriesCount(): number {
     if (!this.products.length) {
       return 0;
     }
 
-    const inStock = this.products.filter((product) => product.stock > 0).length;
-    return Math.round((inStock / this.products.length) * 100);
+    return new Set(this.products.map((product) => product.category)).size;
   }
 
   openCreateModal(): void {
@@ -96,12 +106,12 @@ export class ProductsComponent {
       name: this.form.name.trim(),
       category: this.form.category,
       sku: this.form.sku.trim(),
-      stock: Number(this.form.stock),
-      unit: this.form.unit.trim(),
+      stock: 0,
+      unit: "un",
       price: Number(this.form.price)
     };
 
-    if (!normalizedProduct.name || !normalizedProduct.sku || !normalizedProduct.unit) {
+    if (!normalizedProduct.name || !normalizedProduct.sku) {
       return;
     }
 
@@ -120,6 +130,10 @@ export class ProductsComponent {
     this.storageService.saveProducts(this.products);
   }
 
+  retry(): void {
+    this.loadProducts();
+  }
+
   getProductVisual(productName: string): string {
     if (productName.includes("Pao")) return "visual-bread";
     if (productName.includes("Presunto")) return "visual-coldcuts";
@@ -131,7 +145,29 @@ export class ProductsComponent {
   }
 
   private loadProducts(): void {
-    this.products = this.storageService.getProducts();
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.isUsingFallbackData = false;
+    this.fallbackMessage = "";
+
+    this.productsApiService.listProducts().subscribe({
+      next: (products) => {
+        this.products = products;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.products = this.storageService.getProducts();
+
+        if (!this.products.length) {
+          this.products = mockProducts;
+        }
+
+        this.isUsingFallbackData = true;
+        this.fallbackMessage =
+          "API de produtos indisponivel no momento. Exibindo dados locais para continuarmos a validacao da tela.";
+        this.isLoading = false;
+      },
+    });
   }
 
   private getEmptyForm(): ProductForm {
@@ -140,8 +176,6 @@ export class ProductsComponent {
       name: "",
       category: "Paes",
       sku: "",
-      stock: 0,
-      unit: "un",
       price: 0
     };
   }


### PR DESCRIPTION
## Resumo
Amplia a evolucao do frontend Angular em tres frentes: integracao da tela de `clientes` com a API, integracao inicial da leitura de `produtos` com fallback local e refinamento visual/estrutural do `dashboard`.

## O que entra neste PR
- `HttpClient` habilitado na app Angular
- novo service de frontend para buscar `clientes` da API
- novo service de frontend para buscar `produtos` da API
- tela `clientes` trocada de mock fixo para carregamento HTTP
- modal local de `clientes` para create/edit/delete enquanto a gravacao backend ainda nao esta ativa
- tela `produtos` agora tenta leitura da API primeiro e cai para fallback local quando ela falha
- ocultacao no frontend dos campos de `estoque` e `unidade`, que ainda nao fazem parte do contrato real do backend
- enriquecimento do payload de `clientes` no backend com campos de apresentacao como `initials`, `status`, `debtStatus` e `ticket`
- enriquecimento do payload de `produtos` no backend com campos de apresentacao como `name`, `category`, `sku` e `price`
- filtro de leitura para ocultar registros inativos em `clientes` e `produtos`
- ajuste na inicializacao do Prisma para carregar `.env` no modulo e usar o `PrismaPg` no formato esperado pela versao instalada
- melhoria estrutural e visual do componente de `dashboard`, corrigindo o layout do grafico e adicionando resumo do periodo

## Observacoes
- `clientes` e `produtos` continuam com fallback local de forma intencional para nao bloquear a validacao do frontend enquanto o ambiente da API/banco local estiver instavel
- o modal de `clientes` ainda salva apenas em memoria local da tela; a gravacao real no backend continua como proxima etapa
- `produtos` ainda nao cobre escrita real no backend pela UI
- os dados de `estoque` e `unidade` foram ocultados da interface porque o backend atual ainda nao sustenta esse contrato

## Validacao
- `npm run build:web` passou com sucesso
- a tela Angular passa a tentar `http://localhost:3333/clientes`
- a tela Angular passa a tentar `http://localhost:3333/produtos`
- quando a API nao responde no ambiente local atual, `clientes` e `produtos` usam fallback local com aviso visual
- o componente de `dashboard` foi reestruturado sem quebrar o build do frontend
