### PR TITLE
feat(web): evolui clientes, produtos e dashboard

### DIFF
--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -24,6 +24,7 @@ export function createApp() {
   });
 
   // Concentra todas as rotas da aplicação em um único ponto de entrada.
+  app.use("/api", router);
   app.use(router);
   // Registra o tratamento global de erros como último middleware da aplicação.
   app.use(errorHandler);

--- a/apps/api/src/app.js
+++ b/apps/api/src/app.js
@@ -18,6 +18,10 @@ export function createApp() {
   app.use(express.json());
   // Registra logs HTTP no terminal para facilitar depuração.
   app.use(morgan("dev"));
+  app.use((_request, response, next) => {
+    response.set("Cache-Control", "no-store");
+    next();
+  });
 
   // Concentra todas as rotas da aplicação em um único ponto de entrada.
   app.use(router);

--- a/apps/api/src/config/prisma.js
+++ b/apps/api/src/config/prisma.js
@@ -1,10 +1,12 @@
-import "dotenv/config";
+import dotenv from "dotenv";
 
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
 
-// O adapter usa o driver pg por baixo e conecta no Postgres/Supabase via string de conexão.
+dotenv.config({ path: new URL("../../.env", import.meta.url) });
+
+// O adapter usa o driver pg por baixo e conecta no Postgres configurado para a API.
 const adapter = new PrismaPg(process.env.DATABASE_URL);
 
-// O PrismaClient é exportado como singleton local para ser reutilizado em toda a API.
+// O PrismaClient e exportado como singleton local para ser reutilizado em toda a API.
 export const prisma = new PrismaClient({ adapter });

--- a/apps/api/src/config/prisma.js
+++ b/apps/api/src/config/prisma.js
@@ -1,10 +1,10 @@
+import "dotenv/config";
+
 import { PrismaPg } from "@prisma/adapter-pg";
 import { PrismaClient } from "@prisma/client";
 
 // O adapter usa o driver pg por baixo e conecta no Postgres/Supabase via string de conexão.
-const adapter = new PrismaPg({
-  connectionString: process.env.DATABASE_URL,
-});
+const adapter = new PrismaPg(process.env.DATABASE_URL);
 
 // O PrismaClient é exportado como singleton local para ser reutilizado em toda a API.
 export const prisma = new PrismaClient({ adapter });

--- a/apps/api/src/routes/clientes.routes.js
+++ b/apps/api/src/routes/clientes.routes.js
@@ -22,8 +22,8 @@ clientesRoutes.post(
 
 clientesRoutes.get(
   "/",
-  asyncHandler(async (_request, response) => {
-    const clientes = await listClientes();
+  asyncHandler(async (request, response) => {
+    const clientes = await listClientes(request.query);
 
     response.status(200).json(clientes);
   }),

--- a/apps/api/src/routes/fiado.routes.js
+++ b/apps/api/src/routes/fiado.routes.js
@@ -1,0 +1,69 @@
+import { Router } from "express";
+
+import {
+  createContaFiado,
+  deleteContaFiado,
+  getContaFiadoByClienteId,
+  listContasFiado,
+  registrarCobrancaFiado,
+  updateContaFiado,
+} from "../services/fiadoService.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
+
+const fiadoRoutes = Router();
+
+fiadoRoutes.get(
+  "/",
+  asyncHandler(async (_request, response) => {
+    const contas = await listContasFiado();
+
+    response.status(200).json(contas);
+  }),
+);
+
+fiadoRoutes.post(
+  "/",
+  asyncHandler(async (request, response) => {
+    const conta = await createContaFiado(request.body);
+
+    response.status(201).json(conta);
+  }),
+);
+
+fiadoRoutes.get(
+  "/:clienteId",
+  asyncHandler(async (request, response) => {
+    const conta = await getContaFiadoByClienteId(request.params.clienteId);
+
+    response.status(200).json(conta);
+  }),
+);
+
+fiadoRoutes.put(
+  "/:clienteId",
+  asyncHandler(async (request, response) => {
+    const conta = await updateContaFiado(request.params.clienteId, request.body);
+
+    response.status(200).json(conta);
+  }),
+);
+
+fiadoRoutes.post(
+  "/:clienteId/cobranca",
+  asyncHandler(async (request, response) => {
+    const conta = await registrarCobrancaFiado(request.params.clienteId);
+
+    response.status(200).json(conta);
+  }),
+);
+
+fiadoRoutes.delete(
+  "/:clienteId",
+  asyncHandler(async (request, response) => {
+    await deleteContaFiado(request.params.clienteId);
+
+    response.status(204).send();
+  }),
+);
+
+export { fiadoRoutes };

--- a/apps/api/src/routes/funcionarios.routes.js
+++ b/apps/api/src/routes/funcionarios.routes.js
@@ -22,8 +22,8 @@ funcionariosRoutes.post(
 
 funcionariosRoutes.get(
   "/",
-  asyncHandler(async (_request, response) => {
-    const funcionarios = await listFuncionarios();
+  asyncHandler(async (request, response) => {
+    const funcionarios = await listFuncionarios(request.query);
 
     response.status(200).json(funcionarios);
   }),

--- a/apps/api/src/routes/index.js
+++ b/apps/api/src/routes/index.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 
 import { clientesRoutes } from "./clientes.routes.js";
+import { fiadoRoutes } from "./fiado.routes.js";
 import { funcionariosRoutes } from "./funcionarios.routes.js";
 import { produtosRoutes } from "./produtos.routes.js";
+import { relatoriosRoutes } from "./relatorios.routes.js";
 import { vendasRoutes } from "./vendas.routes.js";
 
 // Router principal da API. Conforme o projeto crescer, outras rotas serão acopladas aqui.
@@ -20,5 +22,7 @@ router.use("/clientes", clientesRoutes);
 router.use("/produtos", produtosRoutes);
 router.use("/funcionarios", funcionariosRoutes);
 router.use("/vendas", vendasRoutes);
+router.use("/fiado", fiadoRoutes);
+router.use("/relatorios", relatoriosRoutes);
 
 export { router };

--- a/apps/api/src/routes/produtos.routes.js
+++ b/apps/api/src/routes/produtos.routes.js
@@ -3,7 +3,9 @@ import { Router } from "express";
 import {
   createProduto,
   deleteProduto,
+  getProdutoByCodigoBarras,
   getProdutoById,
+  listProdutoCategorias,
   listProdutos,
   updateProduto,
 } from "../services/produtoService.js";
@@ -26,6 +28,24 @@ produtosRoutes.get(
     const produtos = await listProdutos();
 
     response.status(200).json(produtos);
+  }),
+);
+
+produtosRoutes.get(
+  "/categorias",
+  asyncHandler(async (_request, response) => {
+    const categorias = await listProdutoCategorias();
+
+    response.status(200).json(categorias);
+  }),
+);
+
+produtosRoutes.get(
+  "/codigo/:codigoBarras",
+  asyncHandler(async (request, response) => {
+    const produto = await getProdutoByCodigoBarras(request.params.codigoBarras);
+
+    response.status(200).json(produto);
   }),
 );
 

--- a/apps/api/src/routes/produtos.routes.js
+++ b/apps/api/src/routes/produtos.routes.js
@@ -24,8 +24,8 @@ produtosRoutes.post(
 
 produtosRoutes.get(
   "/",
-  asyncHandler(async (_request, response) => {
-    const produtos = await listProdutos();
+  asyncHandler(async (request, response) => {
+    const produtos = await listProdutos(request.query);
 
     response.status(200).json(produtos);
   }),

--- a/apps/api/src/routes/relatorios.routes.js
+++ b/apps/api/src/routes/relatorios.routes.js
@@ -1,0 +1,39 @@
+import { Router } from "express";
+
+import {
+  getRelatorioDashboard,
+  getRelatorioDevedores,
+  getRelatorioVendas,
+} from "../services/relatorioService.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
+
+const relatoriosRoutes = Router();
+
+relatoriosRoutes.get(
+  "/vendas",
+  asyncHandler(async (request, response) => {
+    const relatorio = await getRelatorioVendas(request.query);
+
+    response.status(200).json(relatorio);
+  }),
+);
+
+relatoriosRoutes.get(
+  "/devedores",
+  asyncHandler(async (_request, response) => {
+    const devedores = await getRelatorioDevedores();
+
+    response.status(200).json(devedores);
+  }),
+);
+
+relatoriosRoutes.get(
+  "/dashboard",
+  asyncHandler(async (_request, response) => {
+    const dashboard = await getRelatorioDashboard();
+
+    response.status(200).json(dashboard);
+  }),
+);
+
+export { relatoriosRoutes };

--- a/apps/api/src/routes/vendas.routes.js
+++ b/apps/api/src/routes/vendas.routes.js
@@ -22,8 +22,8 @@ vendasRoutes.post(
 
 vendasRoutes.get(
   "/",
-  asyncHandler(async (_request, response) => {
-    const vendas = await listVendas();
+  asyncHandler(async (request, response) => {
+    const vendas = await listVendas(request.query);
 
     response.status(200).json(vendas);
   }),

--- a/apps/api/src/routes/vendas.routes.js
+++ b/apps/api/src/routes/vendas.routes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import {
+  cancelarVenda,
   createVenda,
   deleteVenda,
   getVendaById,
@@ -33,6 +34,15 @@ vendasRoutes.get(
   "/:id",
   asyncHandler(async (request, response) => {
     const venda = await getVendaById(request.params.id);
+
+    response.status(200).json(venda);
+  }),
+);
+
+vendasRoutes.patch(
+  "/:id/cancelar",
+  asyncHandler(async (request, response) => {
+    const venda = await cancelarVenda(request.params.id);
 
     response.status(200).json(venda);
   }),

--- a/apps/api/src/server.js
+++ b/apps/api/src/server.js
@@ -2,15 +2,15 @@ import dotenv from "dotenv";
 
 import { createApp } from "./app.js";
 
-// Carrega variáveis do arquivo .env antes de iniciar a aplicação.
-dotenv.config();
+// Carrega o .env da pasta da API, independentemente do diretório usado para iniciar o processo.
+dotenv.config({ path: new URL("../.env", import.meta.url) });
 
-// Monta a aplicação Express com middlewares e rotas.
+// Monta a aplicacao Express com middlewares e rotas.
 const app = createApp();
 // Usa a porta configurada no ambiente e cai para 3333 no desenvolvimento.
 const port = Number(process.env.PORT ?? 3333);
 
 // Inicia o servidor HTTP da API.
 app.listen(port, () => {
-  console.log(`API da Padaria Pão FresQUIM rodando na porta ${port}`);
+  console.log(`API da Padaria Pao Fresquim rodando na porta ${port}`);
 });

--- a/apps/api/src/services/clienteService.js
+++ b/apps/api/src/services/clienteService.js
@@ -1,5 +1,5 @@
 import { prisma } from "../config/prisma.js";
-import { StatusSerasa } from "../domain/enums.js";
+import { StatusSerasa, StatusVenda } from "../domain/enums.js";
 import { AppError } from "../utils/AppError.js";
 import { ensureEnumValue, parseId, requireFields } from "../utils/validation.js";
 
@@ -7,6 +7,71 @@ const clienteInclude = {
   contaFiado: true,
   vendas: true,
 };
+
+function getClienteInitials(nome) {
+  return nome
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((parte) => parte[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+function getClienteStatus(cliente) {
+  if (!cliente.ativo) {
+    return "Inativo";
+  }
+
+  if (cliente.statusSerasa === StatusSerasa.NEGATIVADO) {
+    return "Bloqueado";
+  }
+
+  return "Ativo";
+}
+
+function getClienteDebtStatus(cliente) {
+  const saldoDevedor = Number(cliente.contaFiado?.saldoDevedor ?? 0);
+
+  if (cliente.statusSerasa === StatusSerasa.NEGATIVADO) {
+    return "Bloqueado";
+  }
+
+  if (saldoDevedor > 0) {
+    return "Fiado ativo";
+  }
+
+  return "Em dia";
+}
+
+function getClienteTicket(cliente) {
+  const vendasValidas = cliente.vendas.filter((venda) => venda.status !== StatusVenda.CANCELADA);
+
+  if (vendasValidas.length === 0) {
+    return 0;
+  }
+
+  const valorTotal = vendasValidas.reduce((soma, venda) => soma + Number(venda.valorTotal), 0);
+
+  return Number((valorTotal / vendasValidas.length).toFixed(2));
+}
+
+function serializeCliente(cliente) {
+  if (!cliente) {
+    return cliente;
+  }
+
+  return {
+    ...cliente,
+    name: cliente.nome,
+    phone: cliente.telefone,
+    address: cliente.endereco,
+    initials: getClienteInitials(cliente.nome),
+    status: getClienteStatus(cliente),
+    debtStatus: getClienteDebtStatus(cliente),
+    ticket: getClienteTicket(cliente),
+  };
+}
 
 function buildClienteData(data, { partial = false } = {}) {
   if (!partial) {
@@ -30,23 +95,28 @@ function buildClienteData(data, { partial = false } = {}) {
 }
 
 export async function createCliente(data) {
-  return prisma.cliente.create({
+  const cliente = await prisma.cliente.create({
     data: buildClienteData(data),
     include: clienteInclude,
   });
+
+  return serializeCliente(cliente);
 }
 
 export async function listClientes() {
-  return prisma.cliente.findMany({
+  const clientes = await prisma.cliente.findMany({
+    where: { ativo: true },
     orderBy: { id: "asc" },
     include: clienteInclude,
   });
+
+  return clientes.map(serializeCliente);
 }
 
 export async function getClienteById(idParam) {
   const id = parseId(idParam);
-  const cliente = await prisma.cliente.findUnique({
-    where: { id },
+  const cliente = await prisma.cliente.findFirst({
+    where: { id, ativo: true },
     include: clienteInclude,
   });
 
@@ -54,7 +124,7 @@ export async function getClienteById(idParam) {
     throw new AppError("Cliente nao encontrado.", 404);
   }
 
-  return cliente;
+  return serializeCliente(cliente);
 }
 
 export async function updateCliente(idParam, data) {
@@ -62,11 +132,13 @@ export async function updateCliente(idParam, data) {
 
   await getClienteById(id);
 
-  return prisma.cliente.update({
+  const cliente = await prisma.cliente.update({
     where: { id },
     data: buildClienteData(data, { partial: true }),
     include: clienteInclude,
   });
+
+  return serializeCliente(cliente);
 }
 
 export async function deleteCliente(idParam) {

--- a/apps/api/src/services/clienteService.js
+++ b/apps/api/src/services/clienteService.js
@@ -103,14 +103,45 @@ export async function createCliente(data) {
   return serializeCliente(cliente);
 }
 
-export async function listClientes() {
-  const clientes = await prisma.cliente.findMany({
-    where: { ativo: true },
-    orderBy: { id: "asc" },
-    include: clienteInclude,
-  });
+export async function listClientes({ busca = "", page = 1, limit = 10 } = {}) {
+  const paginaAtual = Math.max(Number(page) || 1, 1);
+  const limiteAtual = Math.min(Math.max(Number(limit) || 10, 1), 100);
+  const skip = (paginaAtual - 1) * limiteAtual;
+  const termoBusca = String(busca).trim();
+  const where = {
+    ativo: true,
+    ...(termoBusca
+      ? {
+          OR: [
+            { nome: { contains: termoBusca, mode: "insensitive" } },
+            { cpf: { contains: termoBusca, mode: "insensitive" } },
+            { telefone: { contains: termoBusca, mode: "insensitive" } },
+            { endereco: { contains: termoBusca, mode: "insensitive" } },
+          ],
+        }
+      : {}),
+  };
 
-  return clientes.map(serializeCliente);
+  const [clientes, total] = await prisma.$transaction([
+    prisma.cliente.findMany({
+      where,
+      orderBy: { id: "asc" },
+      skip,
+      take: limiteAtual,
+      include: clienteInclude,
+    }),
+    prisma.cliente.count({ where }),
+  ]);
+
+  return {
+    data: clientes.map(serializeCliente),
+    pagination: {
+      page: paginaAtual,
+      limit: limiteAtual,
+      total,
+      totalPages: Math.max(Math.ceil(total / limiteAtual), 1),
+    },
+  };
 }
 
 export async function getClienteById(idParam) {

--- a/apps/api/src/services/fiadoService.js
+++ b/apps/api/src/services/fiadoService.js
@@ -1,0 +1,142 @@
+import { prisma } from "../config/prisma.js";
+import { StatusNotificacao } from "../domain/enums.js";
+import { AppError } from "../utils/AppError.js";
+import { ensureEnumValue, ensurePositiveNumber, parseId, requireFields, toMoney } from "../utils/validation.js";
+
+const fiadoInclude = {
+  cliente: {
+    include: {
+      vendas: {
+        include: {
+          itens: {
+            include: {
+              produto: true,
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+function serializeContaFiado(conta) {
+  if (!conta) {
+    return conta;
+  }
+
+  return {
+    ...conta,
+    saldoDevedor: Number(conta.saldoDevedor),
+  };
+}
+
+async function ensureClienteAtivo(clienteId) {
+  const cliente = await prisma.cliente.findFirst({
+    where: { id: parseId(clienteId, "clienteId"), ativo: true },
+  });
+
+  if (!cliente) {
+    throw new AppError("Cliente informado nao existe ou esta inativo.", 404);
+  }
+
+  return cliente;
+}
+
+export async function listContasFiado() {
+  const contas = await prisma.contaFiado.findMany({
+    where: {
+      saldoDevedor: {
+        gt: 0,
+      },
+    },
+    orderBy: {
+      saldoDevedor: "desc",
+    },
+    include: fiadoInclude,
+  });
+
+  return contas.map(serializeContaFiado);
+}
+
+export async function getContaFiadoByClienteId(clienteIdParam) {
+  const clienteId = parseId(clienteIdParam, "clienteId");
+  const conta = await prisma.contaFiado.findUnique({
+    where: { clienteId },
+    include: fiadoInclude,
+  });
+
+  if (!conta) {
+    throw new AppError("Conta de fiado nao encontrada.", 404);
+  }
+
+  return serializeContaFiado(conta);
+}
+
+export async function createContaFiado(data) {
+  requireFields(data, ["clienteId"]);
+  const clienteId = parseId(data.clienteId, "clienteId");
+
+  await ensureClienteAtivo(clienteId);
+  ensureEnumValue(data.statusNotificacao, Object.values(StatusNotificacao), "statusNotificacao");
+
+  const conta = await prisma.contaFiado.upsert({
+    where: { clienteId },
+    update: {
+      saldoDevedor: data.saldoDevedor !== undefined ? toMoney(ensurePositiveNumber(data.saldoDevedor, "saldoDevedor")) : undefined,
+      statusNotificacao: data.statusNotificacao,
+    },
+    create: {
+      clienteId,
+      saldoDevedor: data.saldoDevedor !== undefined ? toMoney(ensurePositiveNumber(data.saldoDevedor, "saldoDevedor")) : "0.00",
+      statusNotificacao: data.statusNotificacao ?? StatusNotificacao.NENHUMA,
+    },
+    include: fiadoInclude,
+  });
+
+  return serializeContaFiado(conta);
+}
+
+export async function updateContaFiado(clienteIdParam, data) {
+  const clienteId = parseId(clienteIdParam, "clienteId");
+
+  await getContaFiadoByClienteId(clienteId);
+  ensureEnumValue(data.statusNotificacao, Object.values(StatusNotificacao), "statusNotificacao");
+
+  const conta = await prisma.contaFiado.update({
+    where: { clienteId },
+    data: {
+      saldoDevedor: data.saldoDevedor !== undefined ? toMoney(ensurePositiveNumber(data.saldoDevedor, "saldoDevedor")) : undefined,
+      statusNotificacao: data.statusNotificacao,
+      dataUltimaCobranca: data.dataUltimaCobranca ? new Date(data.dataUltimaCobranca) : undefined,
+    },
+    include: fiadoInclude,
+  });
+
+  return serializeContaFiado(conta);
+}
+
+export async function registrarCobrancaFiado(clienteIdParam) {
+  const clienteId = parseId(clienteIdParam, "clienteId");
+
+  await getContaFiadoByClienteId(clienteId);
+
+  const conta = await prisma.contaFiado.update({
+    where: { clienteId },
+    data: {
+      dataUltimaCobranca: new Date(),
+      statusNotificacao: StatusNotificacao.ENVIADA,
+    },
+    include: fiadoInclude,
+  });
+
+  return serializeContaFiado(conta);
+}
+
+export async function deleteContaFiado(clienteIdParam) {
+  const clienteId = parseId(clienteIdParam, "clienteId");
+
+  await getContaFiadoByClienteId(clienteId);
+  await prisma.contaFiado.delete({
+    where: { clienteId },
+  });
+}

--- a/apps/api/src/services/funcionarioService.js
+++ b/apps/api/src/services/funcionarioService.js
@@ -38,7 +38,7 @@ async function buildFuncionarioData(data, { partial = false } = {}) {
       "email",
     ]);
 
-    if (!data.senha && !data.senhaHash) {
+    if (!data.senha) {
       throw new AppError("O campo senha e obrigatorio.", 400);
     }
   }
@@ -70,8 +70,6 @@ async function buildFuncionarioData(data, { partial = false } = {}) {
 
   if (data.senha) {
     funcionarioData.senhaHash = await bcrypt.hash(data.senha, 10);
-  } else if (data.senhaHash) {
-    funcionarioData.senhaHash = data.senhaHash;
   }
 
   return funcionarioData;
@@ -86,8 +84,51 @@ export async function createFuncionario(data) {
   return serializeFuncionario(funcionario);
 }
 
-export async function listFuncionarios() {
+export async function listFuncionarios({ busca = "", page = 1, limit = 10 } = {}) {
+  const paginaAtual = Math.max(Number(page) || 1, 1);
+  const limiteAtual = Math.min(Math.max(Number(limit) || 10, 1), 100);
+  const skip = (paginaAtual - 1) * limiteAtual;
+  const termoBusca = String(busca).trim();
+  const where = {
+    ativo: true,
+    ...(termoBusca
+      ? {
+          OR: [
+            { nome: { contains: termoBusca, mode: "insensitive" } },
+            { cpf: { contains: termoBusca, mode: "insensitive" } },
+            { email: { contains: termoBusca, mode: "insensitive" } },
+            { matricula: { contains: termoBusca, mode: "insensitive" } },
+            { cargo: { contains: termoBusca, mode: "insensitive" } },
+          ],
+        }
+      : {}),
+  };
+
+  const [funcionarios, total] = await prisma.$transaction([
+    prisma.funcionario.findMany({
+      where,
+      orderBy: { id: "asc" },
+      skip,
+      take: limiteAtual,
+      include: funcionarioInclude,
+    }),
+    prisma.funcionario.count({ where }),
+  ]);
+
+  return {
+    data: funcionarios.map(serializeFuncionario),
+    pagination: {
+      page: paginaAtual,
+      limit: limiteAtual,
+      total,
+      totalPages: Math.max(Math.ceil(total / limiteAtual), 1),
+    },
+  };
+}
+
+export async function listFuncionariosLegacy() {
   const funcionarios = await prisma.funcionario.findMany({
+    where: { ativo: true },
     orderBy: { id: "asc" },
     include: funcionarioInclude,
   });
@@ -97,8 +138,8 @@ export async function listFuncionarios() {
 
 export async function getFuncionarioById(idParam) {
   const id = parseId(idParam);
-  const funcionario = await prisma.funcionario.findUnique({
-    where: { id },
+  const funcionario = await prisma.funcionario.findFirst({
+    where: { id, ativo: true },
     include: funcionarioInclude,
   });
 

--- a/apps/api/src/services/produtoService.js
+++ b/apps/api/src/services/produtoService.js
@@ -11,6 +11,22 @@ const produtoInclude = {
   itensVenda: true,
 };
 
+function serializeProduto(produto) {
+  if (!produto) {
+    return produto;
+  }
+
+  return {
+    ...produto,
+    name: produto.nome,
+    category: produto.categoria,
+    sku: produto.codigoBarras,
+    price: Number(produto.precoBase),
+    stock: 0,
+    unit: "un",
+  };
+}
+
 function buildProdutoData(data, { partial = false } = {}) {
   if (!partial) {
     requireFields(data, ["codigoBarras", "nome", "precoBase", "categoria"]);
@@ -32,23 +48,28 @@ function buildProdutoData(data, { partial = false } = {}) {
 }
 
 export async function createProduto(data) {
-  return prisma.produto.create({
+  const produto = await prisma.produto.create({
     data: buildProdutoData(data),
     include: produtoInclude,
   });
+
+  return serializeProduto(produto);
 }
 
 export async function listProdutos() {
-  return prisma.produto.findMany({
+  const produtos = await prisma.produto.findMany({
+    where: { ativo: true },
     orderBy: { id: "asc" },
     include: produtoInclude,
   });
+
+  return produtos.map(serializeProduto);
 }
 
 export async function getProdutoById(idParam) {
   const id = parseId(idParam);
-  const produto = await prisma.produto.findUnique({
-    where: { id },
+  const produto = await prisma.produto.findFirst({
+    where: { id, ativo: true },
     include: produtoInclude,
   });
 
@@ -56,7 +77,7 @@ export async function getProdutoById(idParam) {
     throw new AppError("Produto nao encontrado.", 404);
   }
 
-  return produto;
+  return serializeProduto(produto);
 }
 
 export async function updateProduto(idParam, data) {
@@ -64,11 +85,13 @@ export async function updateProduto(idParam, data) {
 
   await getProdutoById(id);
 
-  return prisma.produto.update({
+  const produto = await prisma.produto.update({
     where: { id },
     data: buildProdutoData(data, { partial: true }),
     include: produtoInclude,
   });
+
+  return serializeProduto(produto);
 }
 
 export async function deleteProduto(idParam) {

--- a/apps/api/src/services/produtoService.js
+++ b/apps/api/src/services/produtoService.js
@@ -7,10 +7,6 @@ import {
   toMoney,
 } from "../utils/validation.js";
 
-const produtoInclude = {
-  itensVenda: true,
-};
-
 function serializeProduto(produto) {
   if (!produto) {
     return produto;
@@ -21,6 +17,8 @@ function serializeProduto(produto) {
     name: produto.nome,
     category: produto.categoria,
     sku: produto.codigoBarras,
+    barcode: produto.codigoBarras,
+    imageUrl: produto.imagemUrl,
     price: Number(produto.precoBase),
     stock: 0,
     unit: "un",
@@ -50,7 +48,6 @@ function buildProdutoData(data, { partial = false } = {}) {
 export async function createProduto(data) {
   const produto = await prisma.produto.create({
     data: buildProdutoData(data),
-    include: produtoInclude,
   });
 
   return serializeProduto(produto);
@@ -60,17 +57,37 @@ export async function listProdutos() {
   const produtos = await prisma.produto.findMany({
     where: { ativo: true },
     orderBy: { id: "asc" },
-    include: produtoInclude,
   });
 
   return produtos.map(serializeProduto);
+}
+
+export async function listProdutoCategorias() {
+  const produtos = await prisma.produto.findMany({
+    where: { ativo: true },
+    select: { categoria: true },
+    orderBy: { categoria: "asc" },
+  });
+
+  return [...new Set(produtos.map((produto) => produto.categoria).filter(Boolean))];
+}
+
+export async function getProdutoByCodigoBarras(codigoBarras) {
+  const produto = await prisma.produto.findFirst({
+    where: { codigoBarras, ativo: true },
+  });
+
+  if (!produto) {
+    throw new AppError("Produto nao encontrado.", 404);
+  }
+
+  return serializeProduto(produto);
 }
 
 export async function getProdutoById(idParam) {
   const id = parseId(idParam);
   const produto = await prisma.produto.findFirst({
     where: { id, ativo: true },
-    include: produtoInclude,
   });
 
   if (!produto) {
@@ -88,7 +105,6 @@ export async function updateProduto(idParam, data) {
   const produto = await prisma.produto.update({
     where: { id },
     data: buildProdutoData(data, { partial: true }),
-    include: produtoInclude,
   });
 
   return serializeProduto(produto);

--- a/apps/api/src/services/produtoService.js
+++ b/apps/api/src/services/produtoService.js
@@ -53,13 +53,45 @@ export async function createProduto(data) {
   return serializeProduto(produto);
 }
 
-export async function listProdutos() {
-  const produtos = await prisma.produto.findMany({
-    where: { ativo: true },
-    orderBy: { id: "asc" },
-  });
+export async function listProdutos({ busca = "", categoria = "", page = 1, limit = 10 } = {}) {
+  const paginaAtual = Math.max(Number(page) || 1, 1);
+  const limiteAtual = Math.min(Math.max(Number(limit) || 10, 1), 100);
+  const skip = (paginaAtual - 1) * limiteAtual;
+  const termoBusca = String(busca).trim();
+  const categoriaFiltro = String(categoria).trim();
+  const where = {
+    ativo: true,
+    ...(categoriaFiltro ? { categoria: categoriaFiltro } : {}),
+    ...(termoBusca
+      ? {
+          OR: [
+            { nome: { contains: termoBusca, mode: "insensitive" } },
+            { codigoBarras: { contains: termoBusca, mode: "insensitive" } },
+            { categoria: { contains: termoBusca, mode: "insensitive" } },
+          ],
+        }
+      : {}),
+  };
 
-  return produtos.map(serializeProduto);
+  const [produtos, total] = await prisma.$transaction([
+    prisma.produto.findMany({
+      where,
+      orderBy: { id: "asc" },
+      skip,
+      take: limiteAtual,
+    }),
+    prisma.produto.count({ where }),
+  ]);
+
+  return {
+    data: produtos.map(serializeProduto),
+    pagination: {
+      page: paginaAtual,
+      limit: limiteAtual,
+      total,
+      totalPages: Math.max(Math.ceil(total / limiteAtual), 1),
+    },
+  };
 }
 
 export async function listProdutoCategorias() {

--- a/apps/api/src/services/relatorioService.js
+++ b/apps/api/src/services/relatorioService.js
@@ -1,0 +1,214 @@
+import { prisma } from "../config/prisma.js";
+import { AppError } from "../utils/AppError.js";
+import { parseId } from "../utils/validation.js";
+
+function parseDateFilter(value, fieldName, fallback) {
+  if (!value) {
+    return fallback;
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new AppError(`O filtro ${fieldName} deve conter uma data valida.`, 400);
+  }
+
+  return date;
+}
+
+function getDefaultDateRange() {
+  const dataFim = new Date();
+  dataFim.setHours(23, 59, 59, 999);
+
+  const dataInicio = new Date(dataFim);
+  dataInicio.setDate(dataInicio.getDate() - 29);
+  dataInicio.setHours(0, 0, 0, 0);
+
+  return { dataInicio, dataFim };
+}
+
+function formatDay(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function buildDateBuckets(dataInicio, dataFim) {
+  const buckets = new Map();
+  const cursor = new Date(dataInicio);
+
+  while (cursor <= dataFim) {
+    buckets.set(formatDay(cursor), {
+      date: formatDay(cursor),
+      day: new Intl.DateTimeFormat("pt-BR", { weekday: "short", timeZone: "UTC" })
+        .format(cursor)
+        .replace(".", "")
+        .toUpperCase(),
+      value: 0,
+      orders: 0,
+    });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return buckets;
+}
+
+export async function getRelatorioVendas({ dataInicio, dataFim, produtoId } = {}) {
+  const defaultRange = getDefaultDateRange();
+  const inicio = parseDateFilter(dataInicio, "dataInicio", defaultRange.dataInicio);
+  const fim = parseDateFilter(dataFim, "dataFim", defaultRange.dataFim);
+
+  fim.setHours(23, 59, 59, 999);
+
+  const produtoFiltro = produtoId ? parseId(produtoId, "produtoId") : null;
+  const where = {
+    dataHora: {
+      gte: inicio,
+      lte: fim,
+    },
+    ...(produtoFiltro
+      ? {
+          itens: {
+            some: {
+              produtoId: produtoFiltro,
+            },
+          },
+        }
+      : {}),
+  };
+
+  const vendas = await prisma.venda.findMany({
+    where,
+    orderBy: { dataHora: "asc" },
+    include: {
+      itens: {
+        include: {
+          produto: true,
+        },
+      },
+    },
+  });
+
+  const totalSold = vendas.reduce((total, venda) => total + Number(venda.valorTotal), 0);
+  const buckets = buildDateBuckets(inicio, fim);
+  const rankingByProduct = new Map();
+
+  for (const venda of vendas) {
+    const bucket = buckets.get(formatDay(venda.dataHora));
+
+    if (bucket) {
+      bucket.value += Number(venda.valorTotal);
+      bucket.orders += 1;
+    }
+
+    for (const item of venda.itens) {
+      const current = rankingByProduct.get(item.produtoId) ?? {
+        id: item.produtoId,
+        name: item.produto?.nome ?? "Produto nao informado",
+        sales: 0,
+        revenue: 0,
+      };
+
+      current.sales += item.quantidade;
+      current.revenue += Number(item.subtotal);
+      rankingByProduct.set(item.produtoId, current);
+    }
+  }
+
+  return {
+    totalSold,
+    totalOrders: vendas.length,
+    averageTicket: vendas.length ? totalSold / vendas.length : 0,
+    dailySales: Array.from(buckets.values()),
+    topProducts: Array.from(rankingByProduct.values())
+      .sort((a, b) => b.sales - a.sales)
+      .slice(0, 5),
+  };
+}
+
+export async function getRelatorioDevedores() {
+  const contas = await prisma.contaFiado.findMany({
+    where: {
+      saldoDevedor: {
+        gt: 0,
+      },
+    },
+    orderBy: {
+      saldoDevedor: "desc",
+    },
+    include: {
+      cliente: {
+        include: {
+          vendas: {
+            include: {
+              itens: {
+                include: {
+                  produto: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  return contas.map((conta) => ({
+    clienteId: conta.clienteId,
+    nome: conta.cliente.nome,
+    telefone: conta.cliente.telefone,
+    totalDevido: Number(conta.saldoDevedor),
+    statusNotificacao: conta.statusNotificacao,
+    produtosComprados: conta.cliente.vendas.flatMap((venda) =>
+      venda.itens.map((item) => ({
+        data: venda.dataHora,
+        produto: item.produto?.nome ?? "Produto nao informado",
+        quantidade: item.quantidade,
+        subtotal: Number(item.subtotal),
+      })),
+    ),
+  }));
+}
+
+export async function getRelatorioDashboard() {
+  const hojeInicio = new Date();
+  hojeInicio.setHours(0, 0, 0, 0);
+
+  const hojeFim = new Date(hojeInicio);
+  hojeFim.setHours(23, 59, 59, 999);
+
+  const ontemInicio = new Date(hojeInicio);
+  ontemInicio.setDate(ontemInicio.getDate() - 1);
+
+  const ontemFim = new Date(ontemInicio);
+  ontemFim.setHours(23, 59, 59, 999);
+
+  const [hoje, ontem, clientesComFiado] = await prisma.$transaction([
+    prisma.venda.aggregate({
+      where: { dataHora: { gte: hojeInicio, lte: hojeFim } },
+      _sum: { valorTotal: true },
+      _avg: { valorTotal: true },
+      _count: { id: true },
+    }),
+    prisma.venda.aggregate({
+      where: { dataHora: { gte: ontemInicio, lte: ontemFim } },
+      _sum: { valorTotal: true },
+    }),
+    prisma.contaFiado.count({
+      where: {
+        saldoDevedor: {
+          gt: 0,
+        },
+      },
+    }),
+  ]);
+  const totalHoje = Number(hoje._sum.valorTotal ?? 0);
+  const totalOntem = Number(ontem._sum.valorTotal ?? 0);
+  const comparativoOntem = totalOntem > 0 ? ((totalHoje - totalOntem) / totalOntem) * 100 : 0;
+
+  return {
+    totalSoldToday: totalHoje,
+    salesCount: hoje._count.id,
+    averageTicket: Number(hoje._avg.valorTotal ?? 0),
+    debtClients: clientesComFiado,
+    comparedToYesterday: comparativoOntem,
+  };
+}

--- a/apps/api/src/services/vendaService.js
+++ b/apps/api/src/services/vendaService.js
@@ -218,11 +218,78 @@ export async function createVenda(data) {
   });
 }
 
-export async function listVendas() {
-  return prisma.venda.findMany({
-    orderBy: { id: "asc" },
-    include: vendaInclude,
+export async function listVendas({ inicio, fim, funcionarioId, page = 1, limit = 10 } = {}) {
+  const paginaAtual = Math.max(Number(page) || 1, 1);
+  const limiteAtual = Math.min(Math.max(Number(limit) || 10, 1), 100);
+  const skip = (paginaAtual - 1) * limiteAtual;
+  const where = {};
+
+  if (funcionarioId) {
+    where.funcionarioId = parseId(funcionarioId, "funcionarioId");
+  }
+
+  if (inicio || fim) {
+    where.dataHora = {};
+
+    if (inicio) {
+      const dataInicio = new Date(inicio);
+
+      if (Number.isNaN(dataInicio.getTime())) {
+        throw new AppError("O filtro inicio deve conter uma data valida.", 400);
+      }
+
+      where.dataHora.gte = dataInicio;
+    }
+
+    if (fim) {
+      const dataFim = new Date(fim);
+
+      if (Number.isNaN(dataFim.getTime())) {
+        throw new AppError("O filtro fim deve conter uma data valida.", 400);
+      }
+
+      dataFim.setHours(23, 59, 59, 999);
+      where.dataHora.lte = dataFim;
+    }
+  }
+
+  const [vendas, total, agregados] = await prisma.$transaction([
+    prisma.venda.findMany({
+      where,
+      orderBy: { dataHora: "desc" },
+      skip,
+      take: limiteAtual,
+      include: vendaInclude,
+    }),
+    prisma.venda.count({ where }),
+    prisma.venda.aggregate({
+      where,
+      _sum: { valorTotal: true },
+      _avg: { valorTotal: true },
+    }),
+  ]);
+  const canceladas = await prisma.venda.count({
+    where: { ...where, status: StatusVenda.CANCELADA },
   });
+  const operadoresAtivos = await prisma.funcionario.count({
+    where: { ativo: true },
+  });
+
+  return {
+    data: vendas,
+    pagination: {
+      page: paginaAtual,
+      limit: limiteAtual,
+      total,
+      totalPages: Math.max(Math.ceil(total / limiteAtual), 1),
+    },
+    summary: {
+      totalSold: Number(agregados._sum.valorTotal ?? 0),
+      averageTicket: Number(agregados._avg.valorTotal ?? 0),
+      canceledSales: canceladas,
+      activeOperators: operadoresAtivos,
+    },
+  };
 }
 
 export async function getVendaById(idParam) {

--- a/apps/api/src/services/vendaService.js
+++ b/apps/api/src/services/vendaService.js
@@ -402,3 +402,32 @@ export async function deleteVenda(idParam) {
     await tx.venda.delete({ where: { id } });
   });
 }
+
+export async function cancelarVenda(idParam) {
+  const id = parseId(idParam);
+
+  return prisma.$transaction(async (tx) => {
+    const venda = await tx.venda.findUnique({
+      where: { id },
+      include: vendaInclude,
+    });
+
+    if (!venda) {
+      throw new AppError("Venda nao encontrada.", 404);
+    }
+
+    if (venda.status === StatusVenda.CANCELADA) {
+      return venda;
+    }
+
+    if (venda.formaPagamento === FormaPagamento.FIADO) {
+      await atualizarSaldoFiado(tx, venda.clienteId, -Number(venda.valorTotal));
+    }
+
+    return tx.venda.update({
+      where: { id },
+      data: { status: StatusVenda.CANCELADA },
+      include: vendaInclude,
+    });
+  });
+}

--- a/apps/web/angular.json
+++ b/apps/web/angular.json
@@ -29,8 +29,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "950kb",
+                  "maximumError": "1.1mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,8 @@
     "@angular/forms": "^21.0.0",
     "@angular/platform-browser": "^21.0.0",
     "@angular/router": "^21.0.0",
+    "@fundamental-ngx/ui5-webcomponents": "^0.62.2",
+    "@ui5/webcomponents": "^2.22.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.8.1",
     "zone.js": "~0.15.0"

--- a/apps/web/src/app/app.config.ts
+++ b/apps/web/src/app/app.config.ts
@@ -1,11 +1,13 @@
 import { ApplicationConfig, LOCALE_ID, provideBrowserGlobalErrorListeners } from "@angular/core";
 import { provideHttpClient } from "@angular/common/http";
+import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { provideRouter } from "@angular/router";
 import { routes } from "./app.routes";
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
+    provideAnimationsAsync(),
     provideHttpClient(),
     provideRouter(routes),
     { provide: LOCALE_ID, useValue: "pt-BR" }

--- a/apps/web/src/app/app.config.ts
+++ b/apps/web/src/app/app.config.ts
@@ -1,10 +1,12 @@
 import { ApplicationConfig, LOCALE_ID, provideBrowserGlobalErrorListeners } from "@angular/core";
+import { provideHttpClient } from "@angular/common/http";
 import { provideRouter } from "@angular/router";
 import { routes } from "./app.routes";
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
+    provideHttpClient(),
     provideRouter(routes),
     { provide: LOCALE_ID, useValue: "pt-BR" }
   ]

--- a/apps/web/src/app/app.routes.ts
+++ b/apps/web/src/app/app.routes.ts
@@ -5,7 +5,6 @@ import { ShellComponent } from "./layout/shell/shell.component";
 import { LoginComponent } from "./features/login/login.component";
 import { DashboardComponent } from "./features/dashboard/dashboard.component";
 import { ClientsComponent } from "./features/clients/clients.component";
-import { ProductsComponent } from "./features/products/products.component";
 import { EmployeesComponent } from "./features/employees/employees.component";
 import { SaleComponent } from "./features/sale/sale.component";
 import { HistoryComponent } from "./features/history/history.component";
@@ -29,7 +28,12 @@ export const routes: Routes = [
       { path: "", pathMatch: "full", redirectTo: "dashboard" },
       { path: "dashboard", component: DashboardComponent, data: { pageId: "dashboard" } },
       { path: "clientes", component: ClientsComponent, data: { pageId: "clientes" } },
-      { path: "produtos", component: ProductsComponent, data: { pageId: "produtos" } },
+      {
+        path: "produtos",
+        loadComponent: () =>
+          import("./features/products/products.component").then((module) => module.ProductsComponent),
+        data: { pageId: "produtos" },
+      },
       { path: "funcionarios", component: EmployeesComponent, data: { pageId: "funcionarios" } },
       { path: "vendas/nova", component: SaleComponent, data: { pageId: "nova-venda" } },
       { path: "historico", component: HistoryComponent, data: { pageId: "historico" } },

--- a/apps/web/src/app/core/mock-data.ts
+++ b/apps/web/src/app/core/mock-data.ts
@@ -48,9 +48,9 @@ export const products: Product[] = [
 ];
 
 export const employees: Employee[] = [
-  { id: "ERP-0942", name: "Joao Jose da Silva", role: "Padeiro chefe", status: "Ativo", monthlyHours: "168h", overtime: "+4h", vacationBalance: "22 dias", attendance: "98.5%", admission: "12 de janeiro de 2021", shift: "05:00 - 14:00" },
-  { id: "ERP-1021", name: "Ana Beatriz Moreira", role: "Caixa", status: "Ativo", monthlyHours: "160h", overtime: "+2h", vacationBalance: "18 dias", attendance: "97.2%", admission: "04 de agosto de 2022", shift: "12:00 - 20:20" },
-  { id: "ERP-1115", name: "Carlos Oliveira", role: "Supervisor", status: "Plantao", monthlyHours: "176h", overtime: "+8h", vacationBalance: "30 dias", attendance: "99.1%", admission: "19 de marco de 2020", shift: "08:00 - 17:00" }
+  { id: 942, name: "Joao Jose da Silva", role: "Padeiro chefe", status: "Ativo", monthlyHours: "168h", overtime: "+4h", vacationBalance: "22 dias", attendance: "98.5%", admission: "12 de janeiro de 2021", shift: "05:00 - 14:00" },
+  { id: 1021, name: "Ana Beatriz Moreira", role: "Caixa", status: "Ativo", monthlyHours: "160h", overtime: "+2h", vacationBalance: "18 dias", attendance: "97.2%", admission: "04 de agosto de 2022", shift: "12:00 - 20:20" },
+  { id: 1115, name: "Carlos Oliveira", role: "Supervisor", status: "Plantao", monthlyHours: "176h", overtime: "+8h", vacationBalance: "30 dias", attendance: "99.1%", admission: "19 de marco de 2020", shift: "08:00 - 17:00" }
 ];
 
 export const initialSales: Sale[] = [

--- a/apps/web/src/app/core/models.ts
+++ b/apps/web/src/app/core/models.ts
@@ -45,7 +45,23 @@ export interface Product {
 }
 
 export interface Employee {
-  id: string;
+  id: number;
+  nome?: string;
+  cpf?: string;
+  telefone?: string;
+  endereco?: string;
+  matricula?: string;
+  cargo?: string;
+  dataAdmissao?: string;
+  contatoEmergencia?: string;
+  accessRole?: "PROPRIETARIO" | "ATENDENTE" | "PADEIRO";
+  email?: string;
+  ativo?: boolean;
+  vendas?: unknown[];
+  registrosPonto?: unknown[];
+  ferias?: unknown[];
+  licencas?: unknown[];
+  atestados?: unknown[];
   name: string;
   role: string;
   status: string;
@@ -59,6 +75,16 @@ export interface Employee {
 
 export interface Sale {
   id: string;
+  dataHora?: string;
+  valorTotal?: number | string;
+  formaPagamento?: string;
+  cliente?: Client | null;
+  funcionario?: Employee | null;
+  itens?: Array<{
+    quantidade: number;
+    subtotal: number | string;
+    produto?: Product | null;
+  }>;
   datetime: string;
   client: string;
   mainProduct: string;

--- a/apps/web/src/app/core/models.ts
+++ b/apps/web/src/app/core/models.ts
@@ -9,6 +9,17 @@ export interface PageMeta {
 export interface Client {
   id: number;
   initials: string;
+  nome?: string;
+  cpf?: string;
+  telefone?: string;
+  endereco?: string;
+  statusSerasa?: string;
+  contaFiado?: {
+    saldoDevedor: number;
+    limiteCredito?: number | null;
+    dataUltimaCobranca?: string | null;
+    statusNotificacao?: string | null;
+  } | null;
   name: string;
   email?: string | null;
   phone: string;
@@ -20,6 +31,11 @@ export interface Client {
 
 export interface Product {
   id: number;
+  codigoBarras?: string;
+  nome?: string;
+  precoBase?: number;
+  categoria?: string;
+  imagemUrl?: string | null;
   name: string;
   category: string;
   sku: string;
@@ -53,11 +69,14 @@ export interface Sale {
 
 export interface Debtor {
   clientId: number;
+  clientName?: string;
+  phone?: string;
   amount: number;
   overdue: string;
   status: string;
   lastPurchase: string;
   lastInstallment: number;
+  statusNotificacao?: string;
 }
 
 export interface ReportProduct {

--- a/apps/web/src/app/core/models.ts
+++ b/apps/web/src/app/core/models.ts
@@ -10,7 +10,7 @@ export interface Client {
   id: number;
   initials: string;
   name: string;
-  email: string;
+  email?: string | null;
   phone: string;
   address: string;
   status: string;

--- a/apps/web/src/app/core/models.ts
+++ b/apps/web/src/app/core/models.ts
@@ -67,6 +67,19 @@ export interface Sale {
   status: string;
 }
 
+export interface CreateSaleItemPayload {
+  produtoId: number;
+  quantidade: number;
+}
+
+export interface CreateSalePayload {
+  funcionarioId: number;
+  clienteId?: number | null;
+  formaPagamento: string;
+  status?: string;
+  itens: CreateSaleItemPayload[];
+}
+
 export interface Debtor {
   clientId: number;
   clientName?: string;

--- a/apps/web/src/app/core/services/clients-api.service.ts
+++ b/apps/web/src/app/core/services/clients-api.service.ts
@@ -1,10 +1,14 @@
 import { Injectable, inject } from "@angular/core";
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpHeaders } from "@angular/common/http";
 import { Observable } from "rxjs";
-import { map } from "rxjs/operators";
+import { map, timeout } from "rxjs/operators";
 import { Client } from "../models";
 
 const API_BASE_URL = "http://localhost:3333";
+const NO_CACHE_HEADERS = new HttpHeaders({
+  "Cache-Control": "no-cache",
+  Pragma: "no-cache",
+});
 
 @Injectable({ providedIn: "root" })
 export class ClientsApiService {
@@ -12,8 +16,11 @@ export class ClientsApiService {
 
   listClients(): Observable<Client[]> {
     return this.http
-      .get<Client[]>(`${API_BASE_URL}/clientes`)
-      .pipe(map((clients) => clients.map((client) => this.normalizeClient(client))));
+      .get<Client[]>(`${API_BASE_URL}/clientes`, { headers: NO_CACHE_HEADERS })
+      .pipe(
+        timeout(8000),
+        map((clients) => clients.map((client) => this.normalizeClient(client))),
+      );
   }
 
   createClient(client: Client): Observable<Client> {

--- a/apps/web/src/app/core/services/clients-api.service.ts
+++ b/apps/web/src/app/core/services/clients-api.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, inject } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { Client } from "../models";
+
+const API_BASE_URL = "http://localhost:3333";
+
+@Injectable({ providedIn: "root" })
+export class ClientsApiService {
+  private readonly http = inject(HttpClient);
+
+  listClients(): Observable<Client[]> {
+    return this.http.get<Client[]>(`${API_BASE_URL}/clientes`);
+  }
+}

--- a/apps/web/src/app/core/services/clients-api.service.ts
+++ b/apps/web/src/app/core/services/clients-api.service.ts
@@ -10,33 +10,57 @@ const NO_CACHE_HEADERS = new HttpHeaders({
   Pragma: "no-cache",
 });
 
+export type PaginatedClientsResponse = {
+  data: Client[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
 @Injectable({ providedIn: "root" })
 export class ClientsApiService {
   private readonly http = inject(HttpClient);
 
   listClients(): Observable<Client[]> {
+    return this.listClientsPage({ limit: 100 }).pipe(map((response) => response.data));
+  }
+
+  listClientsPage(params: { busca?: string; page?: number; limit?: number } = {}): Observable<PaginatedClientsResponse> {
     return this.http
-      .get<Client[]>(`${API_BASE_URL}/clientes`, { headers: NO_CACHE_HEADERS })
+      .get<PaginatedClientsResponse>(`${API_BASE_URL}/api/clientes`, {
+        headers: NO_CACHE_HEADERS,
+        params: {
+          busca: params.busca ?? "",
+          page: String(params.page ?? 1),
+          limit: String(params.limit ?? 10),
+        },
+      })
       .pipe(
         timeout(8000),
-        map((clients) => clients.map((client) => this.normalizeClient(client))),
+        map((response) => ({
+          ...response,
+          data: response.data.map((client) => this.normalizeClient(client)),
+        })),
       );
   }
 
   createClient(client: Client): Observable<Client> {
     return this.http
-      .post<Client>(`${API_BASE_URL}/clientes`, this.toClientePayload(client))
+      .post<Client>(`${API_BASE_URL}/api/clientes`, this.toClientePayload(client))
       .pipe(map((createdClient) => this.normalizeClient(createdClient)));
   }
 
   updateClient(client: Client): Observable<Client> {
     return this.http
-      .put<Client>(`${API_BASE_URL}/clientes/${client.id}`, this.toClientePayload(client))
+      .put<Client>(`${API_BASE_URL}/api/clientes/${client.id}`, this.toClientePayload(client))
       .pipe(map((updatedClient) => this.normalizeClient(updatedClient)));
   }
 
   deleteClient(clientId: number): Observable<void> {
-    return this.http.delete<void>(`${API_BASE_URL}/clientes/${clientId}`);
+    return this.http.delete<void>(`${API_BASE_URL}/api/clientes/${clientId}`);
   }
 
   normalizeClient(client: Client): Client {

--- a/apps/web/src/app/core/services/clients-api.service.ts
+++ b/apps/web/src/app/core/services/clients-api.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
 import { Client } from "../models";
 
 const API_BASE_URL = "http://localhost:3333";
@@ -10,6 +11,66 @@ export class ClientsApiService {
   private readonly http = inject(HttpClient);
 
   listClients(): Observable<Client[]> {
-    return this.http.get<Client[]>(`${API_BASE_URL}/clientes`);
+    return this.http
+      .get<Client[]>(`${API_BASE_URL}/clientes`)
+      .pipe(map((clients) => clients.map((client) => this.normalizeClient(client))));
+  }
+
+  createClient(client: Client): Observable<Client> {
+    return this.http
+      .post<Client>(`${API_BASE_URL}/clientes`, this.toClientePayload(client))
+      .pipe(map((createdClient) => this.normalizeClient(createdClient)));
+  }
+
+  updateClient(client: Client): Observable<Client> {
+    return this.http
+      .put<Client>(`${API_BASE_URL}/clientes/${client.id}`, this.toClientePayload(client))
+      .pipe(map((updatedClient) => this.normalizeClient(updatedClient)));
+  }
+
+  deleteClient(clientId: number): Observable<void> {
+    return this.http.delete<void>(`${API_BASE_URL}/clientes/${clientId}`);
+  }
+
+  normalizeClient(client: Client): Client {
+    const nome = client.nome ?? client.name;
+    const telefone = client.telefone ?? client.phone;
+    const endereco = client.endereco ?? client.address;
+    const statusSerasa = client.statusSerasa ?? client.status;
+
+    return {
+      ...client,
+      nome,
+      telefone,
+      endereco,
+      statusSerasa,
+      name: nome,
+      phone: telefone,
+      address: endereco,
+      status: client.status ?? statusSerasa ?? "Ativo",
+      debtStatus: client.debtStatus ?? (client.contaFiado ? "Fiado ativo" : "Em dia"),
+      ticket: Number(client.ticket ?? 0),
+      initials: client.initials ?? this.getInitials(nome),
+    };
+  }
+
+  private toClientePayload(client: Client) {
+    return {
+      nome: client.nome ?? client.name,
+      telefone: client.telefone ?? client.phone,
+      endereco: client.endereco ?? client.address,
+      cpf: client.cpf,
+      statusSerasa: client.statusSerasa ?? client.status,
+    };
+  }
+
+  private getInitials(name: string): string {
+    return name
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase() ?? "")
+      .join("");
   }
 }

--- a/apps/web/src/app/core/services/employees-api.service.ts
+++ b/apps/web/src/app/core/services/employees-api.service.ts
@@ -1,0 +1,132 @@
+import { Injectable, inject } from "@angular/core";
+import { HttpClient, HttpHeaders } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { map, timeout } from "rxjs/operators";
+import { Employee } from "../models";
+
+const API_BASE_URL = "http://localhost:3333";
+const NO_CACHE_HEADERS = new HttpHeaders({
+  "Cache-Control": "no-cache",
+  Pragma: "no-cache",
+});
+
+export type EmployeePayload = {
+  nome: string;
+  cpf: string;
+  telefone: string;
+  endereco: string;
+  matricula: string;
+  cargo: string;
+  dataAdmissao: string;
+  contatoEmergencia: string;
+  role: "PROPRIETARIO" | "ATENDENTE" | "PADEIRO";
+  email: string;
+  senha?: string;
+  ativo?: boolean;
+};
+
+export type EmployeesListResponse = {
+  data: Employee[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
+@Injectable({ providedIn: "root" })
+export class EmployeesApiService {
+  private readonly http = inject(HttpClient);
+
+  listEmployees(params: { busca?: string; page?: number; limit?: number } = {}): Observable<EmployeesListResponse> {
+    return this.http
+      .get<EmployeesListResponse>(`${API_BASE_URL}/api/funcionarios`, {
+        headers: NO_CACHE_HEADERS,
+        params: {
+          busca: params.busca ?? "",
+          page: String(params.page ?? 1),
+          limit: String(params.limit ?? 10),
+        },
+      })
+      .pipe(
+        timeout(8000),
+        map((response) => ({
+          ...response,
+          data: response.data.map((employee) => this.normalizeEmployee(employee)),
+        })),
+      );
+  }
+
+  createEmployee(employee: EmployeePayload): Observable<Employee> {
+    return this.http
+      .post<Employee>(`${API_BASE_URL}/api/funcionarios`, employee)
+      .pipe(map((createdEmployee) => this.normalizeEmployee(createdEmployee)));
+  }
+
+  updateEmployee(employeeId: number, employee: Partial<EmployeePayload>): Observable<Employee> {
+    return this.http
+      .put<Employee>(`${API_BASE_URL}/api/funcionarios/${employeeId}`, employee)
+      .pipe(map((updatedEmployee) => this.normalizeEmployee(updatedEmployee)));
+  }
+
+  deleteEmployee(employeeId: number): Observable<void> {
+    return this.http.delete<void>(`${API_BASE_URL}/api/funcionarios/${employeeId}`);
+  }
+
+  normalizeEmployee(employee: Employee): Employee {
+    const nome = employee.nome ?? employee.name;
+    const cargo = employee.cargo ?? employee.role;
+    const accessRole = (employee.accessRole ?? employee.role ?? "ATENDENTE") as EmployeePayload["role"];
+    const ativo = employee.ativo ?? employee.status !== "Inativo";
+
+    return {
+      ...employee,
+      id: Number(employee.id),
+      nome,
+      cargo,
+      accessRole,
+      name: nome,
+      role: cargo,
+      status: ativo ? "Ativo" : "Inativo",
+      monthlyHours: employee.monthlyHours ?? this.calculateMonthlyHours(employee.registrosPonto?.length ?? 0),
+      overtime: employee.overtime ?? "0h",
+      vacationBalance: employee.vacationBalance ?? this.formatVacationBalance(employee.ferias?.length ?? 0),
+      attendance: employee.attendance ?? this.formatAttendance(employee.registrosPonto?.length ?? 0),
+      admission: employee.admission ?? this.formatDate(employee.dataAdmissao),
+      shift: employee.shift ?? this.mapRoleToShift(accessRole),
+    };
+  }
+
+  private calculateMonthlyHours(registrosPonto: number): string {
+    return `${Math.min(registrosPonto * 4, 220)}h`;
+  }
+
+  private formatVacationBalance(feriasCount: number): string {
+    return feriasCount > 0 ? `${feriasCount} registro(s)` : "Pendente";
+  }
+
+  private formatAttendance(registrosPonto: number): string {
+    return registrosPonto > 0 ? "Com ponto" : "Sem ponto";
+  }
+
+  private formatDate(date?: string): string {
+    if (!date) {
+      return "Nao informado";
+    }
+
+    return new Intl.DateTimeFormat("pt-BR", { timeZone: "UTC" }).format(new Date(date));
+  }
+
+  private mapRoleToShift(role?: EmployeePayload["role"]): string {
+    if (role === "PADEIRO") {
+      return "Producao";
+    }
+
+    if (role === "PROPRIETARIO") {
+      return "Administrativo";
+    }
+
+    return "Atendimento";
+  }
+}

--- a/apps/web/src/app/core/services/fiado-api.service.ts
+++ b/apps/web/src/app/core/services/fiado-api.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, inject } from "@angular/core";
+import { HttpClient, HttpHeaders } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { map, timeout } from "rxjs/operators";
+import { Debtor } from "../models";
+
+const API_BASE_URL = "http://localhost:3333";
+const NO_CACHE_HEADERS = new HttpHeaders({
+  "Cache-Control": "no-cache",
+  Pragma: "no-cache",
+});
+
+type ContaFiadoApi = {
+  clienteId: number;
+  saldoDevedor: number;
+  dataUltimaCobranca?: string | null;
+  statusNotificacao?: string;
+  cliente: {
+    nome: string;
+    telefone: string;
+    vendas?: Array<{
+      dataHora: string;
+      itens?: Array<{
+        subtotal: number | string;
+        produto?: { nome?: string } | null;
+      }>;
+    }>;
+  };
+};
+
+@Injectable({ providedIn: "root" })
+export class FiadoApiService {
+  private readonly http = inject(HttpClient);
+
+  listDebtors(): Observable<Debtor[]> {
+    return this.http
+      .get<ContaFiadoApi[]>(`${API_BASE_URL}/api/fiado`, { headers: NO_CACHE_HEADERS })
+      .pipe(
+        timeout(8000),
+        map((contas) => contas.map((conta) => this.normalizeDebtor(conta))),
+      );
+  }
+
+  registerCharge(clientId: number): Observable<Debtor> {
+    return this.http
+      .post<ContaFiadoApi>(`${API_BASE_URL}/api/fiado/${clientId}/cobranca`, {})
+      .pipe(map((conta) => this.normalizeDebtor(conta)));
+  }
+
+  private normalizeDebtor(conta: ContaFiadoApi): Debtor {
+    const lastSale = conta.cliente.vendas?.at(-1);
+    const lastItem = lastSale?.itens?.at(-1);
+
+    return {
+      clientId: conta.clienteId,
+      clientName: conta.cliente.nome,
+      phone: conta.cliente.telefone,
+      amount: Number(conta.saldoDevedor),
+      overdue: conta.dataUltimaCobranca
+        ? `Ultima cobranca em ${new Date(conta.dataUltimaCobranca).toLocaleDateString("pt-BR")}`
+        : "Sem cobranca registrada",
+      status: Number(conta.saldoDevedor) > 500 ? "Critico" : "Fiado ativo",
+      lastPurchase: lastItem?.produto?.nome
+        ? `${lastItem.produto.nome} em ${new Date(lastSale?.dataHora ?? "").toLocaleDateString("pt-BR")}`
+        : "Sem compras vinculadas",
+      lastInstallment: Number(lastItem?.subtotal ?? 0),
+      statusNotificacao: conta.statusNotificacao ?? "NENHUMA",
+    };
+  }
+}

--- a/apps/web/src/app/core/services/products-api.service.ts
+++ b/apps/web/src/app/core/services/products-api.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
 import { Product } from "../models";
 
 const API_BASE_URL = "http://localhost:3333";
@@ -10,6 +11,66 @@ export class ProductsApiService {
   private readonly http = inject(HttpClient);
 
   listProducts(): Observable<Product[]> {
-    return this.http.get<Product[]>(`${API_BASE_URL}/produtos`);
+    return this.http
+      .get<Product[]>(`${API_BASE_URL}/produtos`)
+      .pipe(map((products) => products.map((product) => this.normalizeProduct(product))));
+  }
+
+  listCategories(): Observable<string[]> {
+    return this.http.get<string[]>(`${API_BASE_URL}/produtos/categorias`);
+  }
+
+  getByBarcode(codigoBarras: string): Observable<Product> {
+    return this.http
+      .get<Product>(`${API_BASE_URL}/produtos/codigo/${encodeURIComponent(codigoBarras)}`)
+      .pipe(map((product) => this.normalizeProduct(product)));
+  }
+
+  createProduct(product: Product): Observable<Product> {
+    return this.http
+      .post<Product>(`${API_BASE_URL}/produtos`, this.toProdutoPayload(product))
+      .pipe(map((createdProduct) => this.normalizeProduct(createdProduct)));
+  }
+
+  updateProduct(product: Product): Observable<Product> {
+    return this.http
+      .put<Product>(`${API_BASE_URL}/produtos/${product.id}`, this.toProdutoPayload(product))
+      .pipe(map((updatedProduct) => this.normalizeProduct(updatedProduct)));
+  }
+
+  deleteProduct(productId: number): Observable<void> {
+    return this.http.delete<void>(`${API_BASE_URL}/produtos/${productId}`);
+  }
+
+  normalizeProduct(product: Product): Product {
+    const nome = product.nome ?? product.name;
+    const categoria = product.categoria ?? product.category;
+    const codigoBarras = product.codigoBarras ?? product.sku;
+    const precoBase = product.precoBase ?? product.price;
+
+    return {
+      ...product,
+      nome,
+      categoria,
+      codigoBarras,
+      precoBase,
+      name: nome,
+      category: categoria,
+      sku: codigoBarras,
+      price: Number(precoBase),
+      stock: product.stock ?? 0,
+      unit: product.unit ?? "un",
+      imagemUrl: product.imagemUrl ?? null,
+    };
+  }
+
+  private toProdutoPayload(product: Product) {
+    return {
+      codigoBarras: product.codigoBarras ?? product.sku,
+      nome: product.nome ?? product.name,
+      categoria: product.categoria ?? product.category,
+      precoBase: product.precoBase ?? product.price,
+      imagemUrl: product.imagemUrl ?? null,
+    };
   }
 }

--- a/apps/web/src/app/core/services/products-api.service.ts
+++ b/apps/web/src/app/core/services/products-api.service.ts
@@ -6,40 +6,64 @@ import { Product } from "../models";
 
 const API_BASE_URL = "http://localhost:3333";
 
+export type PaginatedProductsResponse = {
+  data: Product[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
 @Injectable({ providedIn: "root" })
 export class ProductsApiService {
   private readonly http = inject(HttpClient);
 
   listProducts(): Observable<Product[]> {
+    return this.listProductsPage({ limit: 100 }).pipe(map((response) => response.data));
+  }
+
+  listProductsPage(params: { busca?: string; categoria?: string; page?: number; limit?: number } = {}): Observable<PaginatedProductsResponse> {
     return this.http
-      .get<Product[]>(`${API_BASE_URL}/produtos`)
-      .pipe(map((products) => products.map((product) => this.normalizeProduct(product))));
+      .get<PaginatedProductsResponse>(`${API_BASE_URL}/api/produtos`, {
+        params: {
+          busca: params.busca ?? "",
+          categoria: params.categoria ?? "",
+          page: String(params.page ?? 1),
+          limit: String(params.limit ?? 10),
+        },
+      })
+      .pipe(map((response) => ({
+        ...response,
+        data: response.data.map((product) => this.normalizeProduct(product)),
+      })));
   }
 
   listCategories(): Observable<string[]> {
-    return this.http.get<string[]>(`${API_BASE_URL}/produtos/categorias`);
+    return this.http.get<string[]>(`${API_BASE_URL}/api/produtos/categorias`);
   }
 
   getByBarcode(codigoBarras: string): Observable<Product> {
     return this.http
-      .get<Product>(`${API_BASE_URL}/produtos/codigo/${encodeURIComponent(codigoBarras)}`)
+      .get<Product>(`${API_BASE_URL}/api/produtos/codigo/${encodeURIComponent(codigoBarras)}`)
       .pipe(map((product) => this.normalizeProduct(product)));
   }
 
   createProduct(product: Product): Observable<Product> {
     return this.http
-      .post<Product>(`${API_BASE_URL}/produtos`, this.toProdutoPayload(product))
+      .post<Product>(`${API_BASE_URL}/api/produtos`, this.toProdutoPayload(product))
       .pipe(map((createdProduct) => this.normalizeProduct(createdProduct)));
   }
 
   updateProduct(product: Product): Observable<Product> {
     return this.http
-      .put<Product>(`${API_BASE_URL}/produtos/${product.id}`, this.toProdutoPayload(product))
+      .put<Product>(`${API_BASE_URL}/api/produtos/${product.id}`, this.toProdutoPayload(product))
       .pipe(map((updatedProduct) => this.normalizeProduct(updatedProduct)));
   }
 
   deleteProduct(productId: number): Observable<void> {
-    return this.http.delete<void>(`${API_BASE_URL}/produtos/${productId}`);
+    return this.http.delete<void>(`${API_BASE_URL}/api/produtos/${productId}`);
   }
 
   normalizeProduct(product: Product): Product {

--- a/apps/web/src/app/core/services/products-api.service.ts
+++ b/apps/web/src/app/core/services/products-api.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, inject } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { Product } from "../models";
+
+const API_BASE_URL = "http://localhost:3333";
+
+@Injectable({ providedIn: "root" })
+export class ProductsApiService {
+  private readonly http = inject(HttpClient);
+
+  listProducts(): Observable<Product[]> {
+    return this.http.get<Product[]>(`${API_BASE_URL}/produtos`);
+  }
+}

--- a/apps/web/src/app/core/services/reports-api.service.ts
+++ b/apps/web/src/app/core/services/reports-api.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, inject } from "@angular/core";
+import { HttpClient, HttpHeaders } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { timeout } from "rxjs/operators";
+
+const API_BASE_URL = "http://localhost:3333";
+const NO_CACHE_HEADERS = new HttpHeaders({
+  "Cache-Control": "no-cache",
+  Pragma: "no-cache",
+});
+
+export type DailySalesReport = {
+  date: string;
+  day: string;
+  value: number;
+  orders: number;
+};
+
+export type TopProductReport = {
+  id: number;
+  name: string;
+  sales: number;
+  revenue: number;
+};
+
+export type SalesReport = {
+  totalSold: number;
+  totalOrders: number;
+  averageTicket: number;
+  dailySales: DailySalesReport[];
+  topProducts: TopProductReport[];
+};
+
+export type DashboardReport = {
+  totalSoldToday: number;
+  salesCount: number;
+  averageTicket: number;
+  debtClients: number;
+  comparedToYesterday: number;
+};
+
+export type DebtorReport = {
+  clienteId: number;
+  nome: string;
+  telefone: string;
+  totalDevido: number;
+  statusNotificacao: string;
+  produtosComprados: Array<{
+    data: string;
+    produto: string;
+    quantidade: number;
+    subtotal: number;
+  }>;
+};
+
+@Injectable({ providedIn: "root" })
+export class ReportsApiService {
+  private readonly http = inject(HttpClient);
+
+  getSalesReport(params: { dataInicio?: string; dataFim?: string; produtoId?: string } = {}): Observable<SalesReport> {
+    return this.http
+      .get<SalesReport>(`${API_BASE_URL}/api/relatorios/vendas`, {
+        headers: NO_CACHE_HEADERS,
+        params: {
+          dataInicio: params.dataInicio ?? "",
+          dataFim: params.dataFim ?? "",
+          produtoId: params.produtoId ?? "",
+        },
+      })
+      .pipe(timeout(8000));
+  }
+
+  getDashboardReport(): Observable<DashboardReport> {
+    return this.http
+      .get<DashboardReport>(`${API_BASE_URL}/api/relatorios/dashboard`, { headers: NO_CACHE_HEADERS })
+      .pipe(timeout(8000));
+  }
+
+  getDebtorsReport(): Observable<DebtorReport[]> {
+    return this.http
+      .get<DebtorReport[]>(`${API_BASE_URL}/api/relatorios/devedores`, { headers: NO_CACHE_HEADERS })
+      .pipe(timeout(8000));
+  }
+}

--- a/apps/web/src/app/core/services/sales-api.service.ts
+++ b/apps/web/src/app/core/services/sales-api.service.ts
@@ -1,0 +1,15 @@
+import { Injectable, inject } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { CreateSalePayload } from "../models";
+
+const API_BASE_URL = "http://localhost:3333";
+
+@Injectable({ providedIn: "root" })
+export class SalesApiService {
+  private readonly http = inject(HttpClient);
+
+  createSale(payload: CreateSalePayload): Observable<unknown> {
+    return this.http.post<unknown>(`${API_BASE_URL}/vendas`, payload);
+  }
+}

--- a/apps/web/src/app/core/services/sales-api.service.ts
+++ b/apps/web/src/app/core/services/sales-api.service.ts
@@ -55,6 +55,12 @@ export class SalesApiService {
     return this.http.post<unknown>(`${API_BASE_URL}/api/vendas`, payload);
   }
 
+  cancelSale(saleId: number | string): Observable<Sale> {
+    return this.http
+      .patch<Sale>(`${API_BASE_URL}/api/vendas/${saleId}/cancelar`, {})
+      .pipe(map((sale) => this.normalizeSale(sale)));
+  }
+
   normalizeSale(sale: Sale): Sale {
     const value = Number(sale.valorTotal ?? sale.value ?? 0);
     const productNames = sale.itens

--- a/apps/web/src/app/core/services/sales-api.service.ts
+++ b/apps/web/src/app/core/services/sales-api.service.ts
@@ -1,15 +1,87 @@
 import { Injectable, inject } from "@angular/core";
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpHeaders } from "@angular/common/http";
 import { Observable } from "rxjs";
-import { CreateSalePayload } from "../models";
+import { map, timeout } from "rxjs/operators";
+import { CreateSalePayload, Sale } from "../models";
 
 const API_BASE_URL = "http://localhost:3333";
+const NO_CACHE_HEADERS = new HttpHeaders({
+  "Cache-Control": "no-cache",
+  Pragma: "no-cache",
+});
+
+export type SalesListResponse = {
+  data: Sale[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+  summary: {
+    totalSold: number;
+    averageTicket: number;
+    canceledSales: number;
+    activeOperators: number;
+  };
+};
 
 @Injectable({ providedIn: "root" })
 export class SalesApiService {
   private readonly http = inject(HttpClient);
 
+  listSales(params: { inicio?: string; fim?: string; funcionarioId?: string; page?: number; limit?: number } = {}): Observable<SalesListResponse> {
+    return this.http
+      .get<SalesListResponse>(`${API_BASE_URL}/api/vendas`, {
+        headers: NO_CACHE_HEADERS,
+        params: {
+          inicio: params.inicio ?? "",
+          fim: params.fim ?? "",
+          funcionarioId: params.funcionarioId ?? "",
+          page: String(params.page ?? 1),
+          limit: String(params.limit ?? 10),
+        },
+      })
+      .pipe(
+        timeout(8000),
+        map((response) => ({
+          ...response,
+          data: response.data.map((sale) => this.normalizeSale(sale)),
+        })),
+      );
+  }
+
   createSale(payload: CreateSalePayload): Observable<unknown> {
-    return this.http.post<unknown>(`${API_BASE_URL}/vendas`, payload);
+    return this.http.post<unknown>(`${API_BASE_URL}/api/vendas`, payload);
+  }
+
+  normalizeSale(sale: Sale): Sale {
+    const value = Number(sale.valorTotal ?? sale.value ?? 0);
+    const productNames = sale.itens
+      ?.map((item) => item.produto?.nome ?? item.produto?.name)
+      .filter(Boolean)
+      .join(", ");
+
+    return {
+      ...sale,
+      id: String(sale.id),
+      datetime: sale.datetime ?? this.formatDateTime(sale.dataHora),
+      client: sale.client ?? sale.cliente?.nome ?? sale.cliente?.name ?? "Cliente nao informado",
+      mainProduct: sale.mainProduct ?? productNames ?? "Itens nao informados",
+      payment: sale.payment ?? sale.formaPagamento ?? "Nao informado",
+      value,
+      status: sale.status ?? "PENDENTE",
+    };
+  }
+
+  private formatDateTime(date?: string): string {
+    if (!date) {
+      return "Nao informado";
+    }
+
+    return new Intl.DateTimeFormat("pt-BR", {
+      dateStyle: "short",
+      timeStyle: "short",
+    }).format(new Date(date));
   }
 }

--- a/apps/web/src/app/features/clients/clients.component.css
+++ b/apps/web/src/app/features/clients/clients.component.css
@@ -160,6 +160,35 @@
   grid-column: 1 / -1;
 }
 
+.serasa-cpf-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.65rem;
+}
+
+.serasa-result {
+  min-height: 48px;
+  display: grid;
+  gap: 0.2rem;
+  padding: 0.72rem 0.9rem;
+  border: 1px solid #bbf7d0;
+  border-radius: 12px;
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.serasa-result.negative {
+  border-color: #fecaca;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.serasa-result span {
+  font-size: 0.78rem;
+  color: inherit;
+  opacity: 0.76;
+}
+
 .client-modal-actions {
   display: flex;
   justify-content: flex-end;
@@ -168,6 +197,10 @@
 
 @media (max-width: 720px) {
   .client-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .serasa-cpf-row {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/src/app/features/clients/clients.component.css
+++ b/apps/web/src/app/features/clients/clients.component.css
@@ -1,3 +1,42 @@
+.clients-page {
+  position: relative;
+}
+
+.clients-header {
+  align-items: start;
+}
+
+.clients-title {
+  font-size: 1.2rem;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+}
+
+.btn-new-client {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  border: 0;
+  border-radius: 8px;
+  padding: 1rem 1.2rem;
+  background: #162236;
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 700;
+  box-shadow: 0 10px 20px rgba(22, 34, 54, 0.18);
+}
+
+.btn-new-icon {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  border: 1.5px solid rgba(255, 255, 255, 0.8);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
 .stats-row {
   margin-bottom: 1rem;
 }
@@ -25,6 +64,110 @@
   margin: 0 0 1rem;
 }
 
+.client-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.icon-action {
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+  color: #90a0b8;
+  padding: 0;
+}
+
+.icon-action svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .retry-button {
   margin-top: 1rem;
+}
+
+.client-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(4px);
+}
+
+.client-modal {
+  width: min(100%, 720px);
+  border-radius: 16px;
+  background: #ffffff;
+  border: 1px solid #e5ebf3;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+}
+
+.client-modal-head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.3rem 1.4rem 1rem;
+  border-bottom: 1px solid #eef2f7;
+}
+
+.client-modal-title {
+  color: #162236;
+  font-size: 1.1rem;
+  font-weight: 800;
+}
+
+.client-modal-subtitle {
+  margin-top: 0.25rem;
+  color: #8290a6;
+  font-size: 0.88rem;
+}
+
+.modal-close {
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 10px;
+  background: #f3f6fa;
+  color: #5d6d84;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.client-form {
+  display: grid;
+  gap: 1.2rem;
+  padding: 1.25rem 1.4rem 1.4rem;
+}
+
+.client-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.client-form-full {
+  grid-column: 1 / -1;
+}
+
+.client-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.8rem;
+}
+
+@media (max-width: 720px) {
+  .client-form-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/apps/web/src/app/features/clients/clients.component.css
+++ b/apps/web/src/app/features/clients/clients.component.css
@@ -24,3 +24,7 @@
 .search-bar {
   margin: 0 0 1rem;
 }
+
+.retry-button {
+  margin-top: 1rem;
+}

--- a/apps/web/src/app/features/clients/clients.component.html
+++ b/apps/web/src/app/features/clients/clients.component.html
@@ -86,10 +86,6 @@
       </div>
     </div>
 
-    <div *ngIf="!isLoading && isUsingFallbackData" class="table-footer fallback-note">
-      <span>{{ fallbackMessage }}</span>
-      <button class="btn-secondary" type="button" (click)="retry()">Tentar API novamente</button>
-    </div>
   </div>
 
   <div *ngIf="isModalOpen" class="client-modal-backdrop" (click)="closeModal()">
@@ -97,7 +93,7 @@
       <div class="client-modal-head">
         <div>
           <div class="client-modal-title">{{ modalMode === 'edit' ? 'Editar cliente' : 'Novo cliente' }}</div>
-          <div class="client-modal-subtitle">Campos alinhados ao backend: nome, CPF, telefone, endereco e status Serasa.</div>
+          <div class="client-modal-subtitle">O status Serasa e calculado por uma consulta fake a partir do CPF informado.</div>
         </div>
         <button class="modal-close" type="button" (click)="closeModal()">×</button>
       </div>
@@ -111,7 +107,12 @@
 
           <div class="form-group">
             <label class="form-label">CPF</label>
-            <input class="form-input" name="cpf" [(ngModel)]="form.cpf" required />
+            <div class="serasa-cpf-row">
+              <input class="form-input" name="cpf" [(ngModel)]="form.cpf" (ngModelChange)="onCpfChange()" required />
+              <button class="btn-secondary compact" type="button" [disabled]="isConsultingSerasa" (click)="consultSerasa()">
+                {{ isConsultingSerasa ? 'Consultando...' : 'Consultar Serasa' }}
+              </button>
+            </div>
           </div>
 
           <div class="form-group">
@@ -131,16 +132,10 @@
 
           <div class="form-group">
             <label class="form-label">Status Serasa</label>
-            <select class="form-select" name="statusSerasa" [(ngModel)]="form.statusSerasa">
-              <option *ngFor="let item of statusOptions" [value]="item">{{ item }}</option>
-            </select>
-          </div>
-
-          <div class="form-group">
-            <label class="form-label">Fiado</label>
-            <select class="form-select" name="debtStatus" [(ngModel)]="form.debtStatus">
-              <option *ngFor="let item of debtStatusOptions" [value]="item">{{ item }}</option>
-            </select>
+            <div class="serasa-result" [class.negative]="form.statusSerasa === 'NEGATIVADO'">
+              <strong>{{ form.statusSerasa }}</strong>
+              <span>{{ serasaMessage }}</span>
+            </div>
           </div>
 
           <div class="form-group client-form-full">

--- a/apps/web/src/app/features/clients/clients.component.html
+++ b/apps/web/src/app/features/clients/clients.component.html
@@ -21,7 +21,7 @@
     <div class="stat-row-item"><div class="stat-row-label">Ticket medio</div><div class="stat-row-value">{{ formatCurrency(averageTicket) }}</div></div>
   </div>
 
-  <input class="search-bar" type="text" placeholder="Buscar clientes por nome ou telefone..." [(ngModel)]="query" />
+  <input class="search-bar" type="text" placeholder="Buscar clientes por nome, CPF ou telefone..." [(ngModel)]="query" />
 
   <div class="table-panel">
     <div *ngIf="isLoading" class="empty-state">Carregando clientes da API...</div>
@@ -35,9 +35,10 @@
       <thead *ngIf="!isLoading && !errorMessage">
         <tr>
           <th>Cliente</th>
+          <th>CPF</th>
           <th>Telefone</th>
           <th>Endereco</th>
-          <th>Status</th>
+          <th>Status Serasa</th>
           <th>Fiado</th>
           <th>Ticket medio</th>
           <th>Acoes</th>
@@ -46,12 +47,13 @@
       <tbody *ngIf="!isLoading && !errorMessage">
         <tr *ngFor="let client of filteredClients">
           <td>
-            <div class="client-name">{{ client.name }}</div>
+            <div class="client-name">{{ client.nome }}</div>
             <div class="client-time">{{ client.email || "Sem e-mail cadastrado" }}</div>
           </td>
-          <td>{{ client.phone }}</td>
-          <td>{{ client.address }}</td>
-          <td><pf-status-badge [text]="client.status" /></td>
+          <td>{{ client.cpf || "Nao informado" }}</td>
+          <td>{{ client.telefone }}</td>
+          <td>{{ client.endereco }}</td>
+          <td><pf-status-badge [text]="client.statusSerasa || client.status" /></td>
           <td><pf-status-badge [text]="client.debtStatus" /></td>
           <td>{{ formatCurrency(client.ticket) }}</td>
           <td>
@@ -70,7 +72,7 @@
           </td>
         </tr>
         <tr *ngIf="filteredClients.length === 0">
-          <td colspan="7" class="empty-state">Nenhum cliente encontrado.</td>
+          <td colspan="8" class="empty-state">Nenhum cliente encontrado.</td>
         </tr>
       </tbody>
     </table>
@@ -95,7 +97,7 @@
       <div class="client-modal-head">
         <div>
           <div class="client-modal-title">{{ modalMode === 'edit' ? 'Editar cliente' : 'Novo cliente' }}</div>
-          <div class="client-modal-subtitle">Os dados serao salvos localmente nesta tela enquanto a gravacao no backend nao estiver ativa.</div>
+          <div class="client-modal-subtitle">Campos alinhados ao backend: nome, CPF, telefone, endereco e status Serasa.</div>
         </div>
         <button class="modal-close" type="button" (click)="closeModal()">×</button>
       </div>
@@ -104,7 +106,12 @@
         <div class="client-form-grid">
           <div class="form-group">
             <label class="form-label">Nome</label>
-            <input class="form-input" name="name" [(ngModel)]="form.name" required />
+            <input class="form-input" name="nome" [(ngModel)]="form.nome" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">CPF</label>
+            <input class="form-input" name="cpf" [(ngModel)]="form.cpf" required />
           </div>
 
           <div class="form-group">
@@ -114,17 +121,17 @@
 
           <div class="form-group">
             <label class="form-label">Telefone</label>
-            <input class="form-input" name="phone" [(ngModel)]="form.phone" required />
+            <input class="form-input" name="telefone" [(ngModel)]="form.telefone" required />
           </div>
 
           <div class="form-group">
             <label class="form-label">Endereco</label>
-            <input class="form-input" name="address" [(ngModel)]="form.address" required />
+            <input class="form-input" name="endereco" [(ngModel)]="form.endereco" required />
           </div>
 
           <div class="form-group">
-            <label class="form-label">Status</label>
-            <select class="form-select" name="status" [(ngModel)]="form.status">
+            <label class="form-label">Status Serasa</label>
+            <select class="form-select" name="statusSerasa" [(ngModel)]="form.statusSerasa">
               <option *ngFor="let item of statusOptions" [value]="item">{{ item }}</option>
             </select>
           </div>

--- a/apps/web/src/app/features/clients/clients.component.html
+++ b/apps/web/src/app/features/clients/clients.component.html
@@ -1,72 +1,152 @@
-<div class="page-header">
-  <div>
-    <div class="page-title">Gestao de clientes</div>
-    <div class="page-subtitle">Gerencie sua base de clientes e controle de credito.</div>
-  </div>
-  <div class="toolbar">
-    <button class="btn-secondary" type="button">Exportar PDF</button>
-    <button class="btn-secondary" type="button">Exportar Excel</button>
-    <button class="btn-primary" type="button">Novo cliente</button>
-  </div>
-</div>
-
-<div class="stats-row">
-  <div class="stat-row-item"><div class="stat-row-label">Total de clientes</div><div class="stat-row-value">{{ totalClients }}</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Clientes ativos</div><div class="stat-row-value green">{{ activeClients }}</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Bloqueados (fiado)</div><div class="stat-row-value red">{{ blockedClients }}</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Ticket medio</div><div class="stat-row-value">{{ formatCurrency(averageTicket) }}</div></div>
-</div>
-
-<input class="search-bar" type="text" placeholder="Buscar clientes por nome ou telefone..." [(ngModel)]="query" />
-
-<div class="table-panel">
-  <div *ngIf="isLoading" class="empty-state">Carregando clientes da API...</div>
-
-  <div *ngIf="!isLoading && errorMessage" class="empty-state">
-    <div>{{ errorMessage }}</div>
-    <button class="btn-secondary retry-button" type="button" (click)="retry()">Tentar novamente</button>
-  </div>
-
-  <table>
-    <thead *ngIf="!isLoading && !errorMessage">
-      <tr>
-        <th>Cliente</th>
-        <th>Telefone</th>
-        <th>Endereco</th>
-        <th>Status</th>
-        <th>Fiado</th>
-        <th>Ticket medio</th>
-      </tr>
-    </thead>
-    <tbody *ngIf="!isLoading && !errorMessage">
-      <tr *ngFor="let client of filteredClients">
-        <td>
-          <div class="client-name">{{ client.name }}</div>
-          <div class="client-time">{{ client.email || "Sem e-mail cadastrado" }}</div>
-        </td>
-        <td>{{ client.phone }}</td>
-        <td>{{ client.address }}</td>
-        <td><pf-status-badge [text]="client.status" /></td>
-        <td><pf-status-badge [text]="client.debtStatus" /></td>
-        <td>{{ formatCurrency(client.ticket) }}</td>
-      </tr>
-      <tr *ngIf="filteredClients.length === 0">
-        <td colspan="6" class="empty-state">Nenhum cliente encontrado.</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <div *ngIf="!isLoading && !errorMessage" class="table-footer">
-    <span>Exibindo {{ filteredClients.length }} de {{ clients.length }} clientes</span>
-    <div class="pagination">
-      <button class="page-btn active" type="button">1</button>
-      <button class="page-btn" type="button">2</button>
-      <button class="page-btn" type="button">3</button>
+<div class="clients-page">
+  <div class="page-header clients-header">
+    <div>
+      <div class="page-title clients-title">Gestao de clientes</div>
+      <div class="page-subtitle">Gerencie sua base de clientes e controle de credito.</div>
+    </div>
+    <div class="toolbar">
+      <button class="btn-secondary" type="button">Exportar PDF</button>
+      <button class="btn-secondary" type="button">Exportar Excel</button>
+      <button class="btn-new-client" type="button" (click)="openCreateModal()">
+        <span class="btn-new-icon">+</span>
+        <span>Novo cliente</span>
+      </button>
     </div>
   </div>
 
-  <div *ngIf="!isLoading && isUsingFallbackData" class="table-footer fallback-note">
-    <span>{{ fallbackMessage }}</span>
-    <button class="btn-secondary" type="button" (click)="retry()">Tentar API novamente</button>
+  <div class="stats-row">
+    <div class="stat-row-item"><div class="stat-row-label">Total de clientes</div><div class="stat-row-value">{{ totalClients }}</div></div>
+    <div class="stat-row-item"><div class="stat-row-label">Clientes ativos</div><div class="stat-row-value green">{{ activeClients }}</div></div>
+    <div class="stat-row-item"><div class="stat-row-label">Bloqueados (fiado)</div><div class="stat-row-value red">{{ blockedClients }}</div></div>
+    <div class="stat-row-item"><div class="stat-row-label">Ticket medio</div><div class="stat-row-value">{{ formatCurrency(averageTicket) }}</div></div>
+  </div>
+
+  <input class="search-bar" type="text" placeholder="Buscar clientes por nome ou telefone..." [(ngModel)]="query" />
+
+  <div class="table-panel">
+    <div *ngIf="isLoading" class="empty-state">Carregando clientes da API...</div>
+
+    <div *ngIf="!isLoading && errorMessage" class="empty-state">
+      <div>{{ errorMessage }}</div>
+      <button class="btn-secondary retry-button" type="button" (click)="retry()">Tentar novamente</button>
+    </div>
+
+    <table>
+      <thead *ngIf="!isLoading && !errorMessage">
+        <tr>
+          <th>Cliente</th>
+          <th>Telefone</th>
+          <th>Endereco</th>
+          <th>Status</th>
+          <th>Fiado</th>
+          <th>Ticket medio</th>
+          <th>Acoes</th>
+        </tr>
+      </thead>
+      <tbody *ngIf="!isLoading && !errorMessage">
+        <tr *ngFor="let client of filteredClients">
+          <td>
+            <div class="client-name">{{ client.name }}</div>
+            <div class="client-time">{{ client.email || "Sem e-mail cadastrado" }}</div>
+          </td>
+          <td>{{ client.phone }}</td>
+          <td>{{ client.address }}</td>
+          <td><pf-status-badge [text]="client.status" /></td>
+          <td><pf-status-badge [text]="client.debtStatus" /></td>
+          <td>{{ formatCurrency(client.ticket) }}</td>
+          <td>
+            <div class="client-actions">
+              <button class="icon-action" type="button" aria-label="Editar cliente" (click)="openEditModal(client)">
+                <svg viewBox="0 0 24 24" fill="none">
+                  <path d="M4 20h4l10-10-4-4L4 16v4ZM13 7l4 4" />
+                </svg>
+              </button>
+              <button class="icon-action" type="button" aria-label="Excluir cliente" (click)="deleteClient(client.id)">
+                <svg viewBox="0 0 24 24" fill="none">
+                  <path d="M5 7h14M9 7V4h6v3M8 10v7M12 10v7M16 10v7M7 7l1 13h8l1-13" />
+                </svg>
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr *ngIf="filteredClients.length === 0">
+          <td colspan="7" class="empty-state">Nenhum cliente encontrado.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div *ngIf="!isLoading && !errorMessage" class="table-footer">
+      <span>Exibindo {{ filteredClients.length }} de {{ clients.length }} clientes</span>
+      <div class="pagination">
+        <button class="page-btn active" type="button">1</button>
+        <button class="page-btn" type="button">2</button>
+        <button class="page-btn" type="button">3</button>
+      </div>
+    </div>
+
+    <div *ngIf="!isLoading && isUsingFallbackData" class="table-footer fallback-note">
+      <span>{{ fallbackMessage }}</span>
+      <button class="btn-secondary" type="button" (click)="retry()">Tentar API novamente</button>
+    </div>
+  </div>
+
+  <div *ngIf="isModalOpen" class="client-modal-backdrop" (click)="closeModal()">
+    <div class="client-modal" (click)="$event.stopPropagation()">
+      <div class="client-modal-head">
+        <div>
+          <div class="client-modal-title">{{ modalMode === 'edit' ? 'Editar cliente' : 'Novo cliente' }}</div>
+          <div class="client-modal-subtitle">Os dados serao salvos localmente nesta tela enquanto a gravacao no backend nao estiver ativa.</div>
+        </div>
+        <button class="modal-close" type="button" (click)="closeModal()">×</button>
+      </div>
+
+      <form class="client-form" (ngSubmit)="submitForm()">
+        <div class="client-form-grid">
+          <div class="form-group">
+            <label class="form-label">Nome</label>
+            <input class="form-input" name="name" [(ngModel)]="form.name" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">E-mail</label>
+            <input class="form-input" name="email" type="email" [(ngModel)]="form.email" />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Telefone</label>
+            <input class="form-input" name="phone" [(ngModel)]="form.phone" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Endereco</label>
+            <input class="form-input" name="address" [(ngModel)]="form.address" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Status</label>
+            <select class="form-select" name="status" [(ngModel)]="form.status">
+              <option *ngFor="let item of statusOptions" [value]="item">{{ item }}</option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Fiado</label>
+            <select class="form-select" name="debtStatus" [(ngModel)]="form.debtStatus">
+              <option *ngFor="let item of debtStatusOptions" [value]="item">{{ item }}</option>
+            </select>
+          </div>
+
+          <div class="form-group client-form-full">
+            <label class="form-label">Ticket medio</label>
+            <input class="form-input" name="ticket" type="number" min="0" step="0.01" [(ngModel)]="form.ticket" required />
+          </div>
+        </div>
+
+        <div class="client-modal-actions">
+          <button class="btn-secondary" type="button" (click)="closeModal()">Cancelar</button>
+          <button class="btn-primary" type="submit">{{ modalMode === 'edit' ? 'Salvar alteracoes' : 'Cadastrar cliente' }}</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>

--- a/apps/web/src/app/features/clients/clients.component.html
+++ b/apps/web/src/app/features/clients/clients.component.html
@@ -11,17 +11,24 @@
 </div>
 
 <div class="stats-row">
-  <div class="stat-row-item"><div class="stat-row-label">Total de clientes</div><div class="stat-row-value">1.284</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Clientes ativos</div><div class="stat-row-value green">1.120</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Bloqueados (fiado)</div><div class="stat-row-value red">164</div></div>
-  <div class="stat-row-item"><div class="stat-row-label">Ticket medio</div><div class="stat-row-value">{{ formatCurrency(452) }}</div></div>
+  <div class="stat-row-item"><div class="stat-row-label">Total de clientes</div><div class="stat-row-value">{{ totalClients }}</div></div>
+  <div class="stat-row-item"><div class="stat-row-label">Clientes ativos</div><div class="stat-row-value green">{{ activeClients }}</div></div>
+  <div class="stat-row-item"><div class="stat-row-label">Bloqueados (fiado)</div><div class="stat-row-value red">{{ blockedClients }}</div></div>
+  <div class="stat-row-item"><div class="stat-row-label">Ticket medio</div><div class="stat-row-value">{{ formatCurrency(averageTicket) }}</div></div>
 </div>
 
 <input class="search-bar" type="text" placeholder="Buscar clientes por nome ou telefone..." [(ngModel)]="query" />
 
 <div class="table-panel">
+  <div *ngIf="isLoading" class="empty-state">Carregando clientes da API...</div>
+
+  <div *ngIf="!isLoading && errorMessage" class="empty-state">
+    <div>{{ errorMessage }}</div>
+    <button class="btn-secondary retry-button" type="button" (click)="retry()">Tentar novamente</button>
+  </div>
+
   <table>
-    <thead>
+    <thead *ngIf="!isLoading && !errorMessage">
       <tr>
         <th>Cliente</th>
         <th>Telefone</th>
@@ -31,11 +38,11 @@
         <th>Ticket medio</th>
       </tr>
     </thead>
-    <tbody>
+    <tbody *ngIf="!isLoading && !errorMessage">
       <tr *ngFor="let client of filteredClients">
         <td>
           <div class="client-name">{{ client.name }}</div>
-          <div class="client-time">{{ client.email }}</div>
+          <div class="client-time">{{ client.email || "Sem e-mail cadastrado" }}</div>
         </td>
         <td>{{ client.phone }}</td>
         <td>{{ client.address }}</td>
@@ -43,15 +50,23 @@
         <td><pf-status-badge [text]="client.debtStatus" /></td>
         <td>{{ formatCurrency(client.ticket) }}</td>
       </tr>
+      <tr *ngIf="filteredClients.length === 0">
+        <td colspan="6" class="empty-state">Nenhum cliente encontrado.</td>
+      </tr>
     </tbody>
   </table>
 
-  <div class="table-footer">
-    <span>Exibindo {{ filteredClients.length }} de {{ clients.length }} clientes simulados</span>
+  <div *ngIf="!isLoading && !errorMessage" class="table-footer">
+    <span>Exibindo {{ filteredClients.length }} de {{ clients.length }} clientes</span>
     <div class="pagination">
       <button class="page-btn active" type="button">1</button>
       <button class="page-btn" type="button">2</button>
       <button class="page-btn" type="button">3</button>
     </div>
+  </div>
+
+  <div *ngIf="!isLoading && isUsingFallbackData" class="table-footer fallback-note">
+    <span>{{ fallbackMessage }}</span>
+    <button class="btn-secondary" type="button" (click)="retry()">Tentar API novamente</button>
   </div>
 </div>

--- a/apps/web/src/app/features/clients/clients.component.ts
+++ b/apps/web/src/app/features/clients/clients.component.ts
@@ -9,11 +9,12 @@ import { formatCurrency } from "../../core/utils/format";
 
 type ClientForm = {
   id: number | null;
-  name: string;
+  nome: string;
+  cpf: string;
   email: string;
-  phone: string;
-  address: string;
-  status: string;
+  telefone: string;
+  endereco: string;
+  statusSerasa: string;
   debtStatus: string;
   ticket: number;
 };
@@ -35,7 +36,7 @@ export class ClientsComponent implements OnInit {
   isModalOpen = false;
   modalMode: "create" | "edit" = "create";
   readonly formatCurrency = formatCurrency;
-  readonly statusOptions = ["Ativo", "Bloqueado", "VIP", "Inativo"];
+  readonly statusOptions = ["REGULAR", "NEGATIVADO"];
   readonly debtStatusOptions = ["Em dia", "Fiado ativo", "Bloqueado", "Critico", "Acompanhando"];
   form: ClientForm = this.getEmptyForm();
 
@@ -48,7 +49,7 @@ export class ClientsComponent implements OnInit {
   get filteredClients() {
     const normalized = this.query.toLowerCase();
     return this.clients.filter((client) =>
-      [client.name, client.email ?? "", client.phone].some((value) =>
+      [client.nome ?? client.name, client.email ?? "", client.cpf ?? "", client.telefone ?? client.phone].some((value) =>
         value.toLowerCase().includes(normalized),
       )
     );
@@ -59,11 +60,11 @@ export class ClientsComponent implements OnInit {
   }
 
   get activeClients(): number {
-    return this.clients.filter((client) => client.status === "Ativo").length;
+    return this.clients.filter((client) => (client.statusSerasa ?? client.status) !== "NEGATIVADO").length;
   }
 
   get blockedClients(): number {
-    return this.clients.filter((client) => client.status === "Bloqueado").length;
+    return this.clients.filter((client) => (client.statusSerasa ?? client.status) === "NEGATIVADO").length;
   }
 
   get averageTicket(): number {
@@ -90,11 +91,12 @@ export class ClientsComponent implements OnInit {
     this.modalMode = "edit";
     this.form = {
       id: client.id,
-      name: client.name,
+      nome: client.nome ?? client.name,
+      cpf: client.cpf ?? "",
       email: client.email ?? "",
-      phone: client.phone,
-      address: client.address,
-      status: client.status,
+      telefone: client.telefone ?? client.phone,
+      endereco: client.endereco ?? client.address,
+      statusSerasa: client.statusSerasa ?? client.status,
       debtStatus: client.debtStatus,
       ticket: client.ticket,
     };
@@ -109,33 +111,51 @@ export class ClientsComponent implements OnInit {
   submitForm(): void {
     const normalizedClient: Client = {
       id: this.form.id ?? this.generateNextId(),
-      initials: this.getInitials(this.form.name),
-      name: this.form.name.trim(),
+      initials: this.getInitials(this.form.nome),
+      nome: this.form.nome.trim(),
+      cpf: this.form.cpf.trim(),
+      telefone: this.form.telefone.trim(),
+      endereco: this.form.endereco.trim(),
+      statusSerasa: this.form.statusSerasa,
+      name: this.form.nome.trim(),
       email: this.form.email.trim() || null,
-      phone: this.form.phone.trim(),
-      address: this.form.address.trim(),
-      status: this.form.status,
+      phone: this.form.telefone.trim(),
+      address: this.form.endereco.trim(),
+      status: this.form.statusSerasa,
       debtStatus: this.form.debtStatus,
       ticket: Number(this.form.ticket),
     };
 
-    if (!normalizedClient.name || !normalizedClient.phone || !normalizedClient.address) {
+    if (!normalizedClient.nome || !normalizedClient.cpf || !normalizedClient.telefone || !normalizedClient.endereco) {
       return;
     }
 
     if (this.modalMode === "edit" && this.form.id !== null) {
-      this.clients = this.clients.map((client) =>
-        client.id === this.form.id ? normalizedClient : client,
-      );
+      this.clientsApiService.updateClient(normalizedClient).subscribe({
+        next: (updatedClient) => {
+          this.clients = this.clients.map((client) =>
+            client.id === this.form.id ? updatedClient : client,
+          );
+          this.closeModal();
+        },
+        error: () => this.saveClientLocally(normalizedClient),
+      });
     } else {
-      this.clients = [normalizedClient, ...this.clients];
+      this.clientsApiService.createClient(normalizedClient).subscribe({
+        next: (createdClient) => {
+          this.clients = [createdClient, ...this.clients];
+          this.closeModal();
+        },
+        error: () => this.saveClientLocally(normalizedClient),
+      });
     }
-
-    this.closeModal();
   }
 
   deleteClient(clientId: number): void {
-    this.clients = this.clients.filter((client) => client.id !== clientId);
+    this.clientsApiService.deleteClient(clientId).subscribe({
+      next: () => this.removeClientLocally(clientId),
+      error: () => this.removeClientLocally(clientId),
+    });
   }
 
   private loadClients(): void {
@@ -146,11 +166,11 @@ export class ClientsComponent implements OnInit {
 
     this.clientsApiService.listClients().subscribe({
       next: (clients) => {
-        this.clients = clients;
+        this.clients = clients.map((client) => this.clientsApiService.normalizeClient(client));
         this.isLoading = false;
       },
       error: () => {
-        this.clients = mockClients;
+        this.clients = mockClients.map((client) => this.clientsApiService.normalizeClient(client));
         this.isUsingFallbackData = true;
         this.fallbackMessage = "API de clientes indisponivel no momento. Exibindo dados locais para continuarmos a validacao da tela.";
         this.isLoading = false;
@@ -161,11 +181,12 @@ export class ClientsComponent implements OnInit {
   private getEmptyForm(): ClientForm {
     return {
       id: null,
-      name: "",
+      nome: "",
+      cpf: "",
       email: "",
-      phone: "",
-      address: "",
-      status: "Ativo",
+      telefone: "",
+      endereco: "",
+      statusSerasa: "REGULAR",
       debtStatus: "Em dia",
       ticket: 0,
     };
@@ -183,5 +204,26 @@ export class ClientsComponent implements OnInit {
 
   private generateNextId(): number {
     return this.clients.reduce((max, client) => Math.max(max, client.id), 0) + 1;
+  }
+
+  private saveClientLocally(client: Client): void {
+    const normalizedClient = this.clientsApiService.normalizeClient(client);
+
+    if (this.modalMode === "edit" && this.form.id !== null) {
+      this.clients = this.clients.map((currentClient) =>
+        currentClient.id === this.form.id ? normalizedClient : currentClient,
+      );
+    } else {
+      this.clients = [normalizedClient, ...this.clients];
+    }
+
+    this.isUsingFallbackData = true;
+    this.fallbackMessage =
+      "API de clientes indisponivel. Alteracao aplicada localmente para manter a validacao da tela.";
+    this.closeModal();
+  }
+
+  private removeClientLocally(clientId: number): void {
+    this.clients = this.clients.filter((client) => client.id !== clientId);
   }
 }

--- a/apps/web/src/app/features/clients/clients.component.ts
+++ b/apps/web/src/app/features/clients/clients.component.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
-import { clients } from "../../core/mock-data";
+import { Client } from "../../core/models";
+import { clients as mockClients } from "../../core/mock-data";
+import { ClientsApiService } from "../../core/services/clients-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 import { formatCurrency } from "../../core/utils/format";
 
@@ -12,15 +14,73 @@ import { formatCurrency } from "../../core/utils/format";
   templateUrl: "./clients.component.html",
   styleUrl: "./clients.component.css"
 })
-export class ClientsComponent {
+export class ClientsComponent implements OnInit {
   query = "";
-  readonly clients = clients;
+  clients: Client[] = [];
+  isLoading = true;
+  errorMessage = "";
+  isUsingFallbackData = false;
+  fallbackMessage = "";
   readonly formatCurrency = formatCurrency;
+
+  constructor(private readonly clientsApiService: ClientsApiService) {}
+
+  ngOnInit(): void {
+    this.loadClients();
+  }
 
   get filteredClients() {
     const normalized = this.query.toLowerCase();
     return this.clients.filter((client) =>
-      [client.name, client.email, client.phone].some((value) => value.toLowerCase().includes(normalized))
+      [client.name, client.email ?? "", client.phone].some((value) =>
+        value.toLowerCase().includes(normalized),
+      )
     );
+  }
+
+  get totalClients(): number {
+    return this.clients.length;
+  }
+
+  get activeClients(): number {
+    return this.clients.filter((client) => client.status === "Ativo").length;
+  }
+
+  get blockedClients(): number {
+    return this.clients.filter((client) => client.status === "Bloqueado").length;
+  }
+
+  get averageTicket(): number {
+    if (!this.clients.length) {
+      return 0;
+    }
+
+    const total = this.clients.reduce((sum, client) => sum + client.ticket, 0);
+
+    return Number((total / this.clients.length).toFixed(2));
+  }
+
+  retry(): void {
+    this.loadClients();
+  }
+
+  private loadClients(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.isUsingFallbackData = false;
+    this.fallbackMessage = "";
+
+    this.clientsApiService.listClients().subscribe({
+      next: (clients) => {
+        this.clients = clients;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.clients = mockClients;
+        this.isUsingFallbackData = true;
+        this.fallbackMessage = "API de clientes indisponivel no momento. Exibindo dados locais para continuarmos a validacao da tela.";
+        this.isLoading = false;
+      },
+    });
   }
 }

--- a/apps/web/src/app/features/clients/clients.component.ts
+++ b/apps/web/src/app/features/clients/clients.component.ts
@@ -7,6 +7,17 @@ import { ClientsApiService } from "../../core/services/clients-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 import { formatCurrency } from "../../core/utils/format";
 
+type ClientForm = {
+  id: number | null;
+  name: string;
+  email: string;
+  phone: string;
+  address: string;
+  status: string;
+  debtStatus: string;
+  ticket: number;
+};
+
 @Component({
   selector: "pf-clients",
   standalone: true,
@@ -21,7 +32,12 @@ export class ClientsComponent implements OnInit {
   errorMessage = "";
   isUsingFallbackData = false;
   fallbackMessage = "";
+  isModalOpen = false;
+  modalMode: "create" | "edit" = "create";
   readonly formatCurrency = formatCurrency;
+  readonly statusOptions = ["Ativo", "Bloqueado", "VIP", "Inativo"];
+  readonly debtStatusOptions = ["Em dia", "Fiado ativo", "Bloqueado", "Critico", "Acompanhando"];
+  form: ClientForm = this.getEmptyForm();
 
   constructor(private readonly clientsApiService: ClientsApiService) {}
 
@@ -64,6 +80,64 @@ export class ClientsComponent implements OnInit {
     this.loadClients();
   }
 
+  openCreateModal(): void {
+    this.modalMode = "create";
+    this.form = this.getEmptyForm();
+    this.isModalOpen = true;
+  }
+
+  openEditModal(client: Client): void {
+    this.modalMode = "edit";
+    this.form = {
+      id: client.id,
+      name: client.name,
+      email: client.email ?? "",
+      phone: client.phone,
+      address: client.address,
+      status: client.status,
+      debtStatus: client.debtStatus,
+      ticket: client.ticket,
+    };
+    this.isModalOpen = true;
+  }
+
+  closeModal(): void {
+    this.isModalOpen = false;
+    this.form = this.getEmptyForm();
+  }
+
+  submitForm(): void {
+    const normalizedClient: Client = {
+      id: this.form.id ?? this.generateNextId(),
+      initials: this.getInitials(this.form.name),
+      name: this.form.name.trim(),
+      email: this.form.email.trim() || null,
+      phone: this.form.phone.trim(),
+      address: this.form.address.trim(),
+      status: this.form.status,
+      debtStatus: this.form.debtStatus,
+      ticket: Number(this.form.ticket),
+    };
+
+    if (!normalizedClient.name || !normalizedClient.phone || !normalizedClient.address) {
+      return;
+    }
+
+    if (this.modalMode === "edit" && this.form.id !== null) {
+      this.clients = this.clients.map((client) =>
+        client.id === this.form.id ? normalizedClient : client,
+      );
+    } else {
+      this.clients = [normalizedClient, ...this.clients];
+    }
+
+    this.closeModal();
+  }
+
+  deleteClient(clientId: number): void {
+    this.clients = this.clients.filter((client) => client.id !== clientId);
+  }
+
   private loadClients(): void {
     this.isLoading = true;
     this.errorMessage = "";
@@ -82,5 +156,32 @@ export class ClientsComponent implements OnInit {
         this.isLoading = false;
       },
     });
+  }
+
+  private getEmptyForm(): ClientForm {
+    return {
+      id: null,
+      name: "",
+      email: "",
+      phone: "",
+      address: "",
+      status: "Ativo",
+      debtStatus: "Em dia",
+      ticket: 0,
+    };
+  }
+
+  private getInitials(name: string): string {
+    return name
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .slice(0, 2)
+      .map((part) => part[0]?.toUpperCase() ?? "")
+      .join("");
+  }
+
+  private generateNextId(): number {
+    return this.clients.reduce((max, client) => Math.max(max, client.id), 0) + 1;
   }
 }

--- a/apps/web/src/app/features/clients/clients.component.ts
+++ b/apps/web/src/app/features/clients/clients.component.ts
@@ -1,8 +1,7 @@
 import { CommonModule } from "@angular/common";
-import { Component, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, NgZone, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { Client } from "../../core/models";
-import { clients as mockClients } from "../../core/mock-data";
 import { ClientsApiService } from "../../core/services/clients-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 import { formatCurrency } from "../../core/utils/format";
@@ -15,7 +14,6 @@ type ClientForm = {
   telefone: string;
   endereco: string;
   statusSerasa: string;
-  debtStatus: string;
   ticket: number;
 };
 
@@ -31,16 +29,19 @@ export class ClientsComponent implements OnInit {
   clients: Client[] = [];
   isLoading = true;
   errorMessage = "";
-  isUsingFallbackData = false;
-  fallbackMessage = "";
   isModalOpen = false;
   modalMode: "create" | "edit" = "create";
   readonly formatCurrency = formatCurrency;
-  readonly statusOptions = ["REGULAR", "NEGATIVADO"];
-  readonly debtStatusOptions = ["Em dia", "Fiado ativo", "Bloqueado", "Critico", "Acompanhando"];
+  serasaConsultedCpf = "";
+  isConsultingSerasa = false;
+  serasaMessage = "Informe o CPF e consulte o status antes de salvar.";
   form: ClientForm = this.getEmptyForm();
 
-  constructor(private readonly clientsApiService: ClientsApiService) {}
+  constructor(
+    private readonly clientsApiService: ClientsApiService,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly ngZone: NgZone,
+  ) {}
 
   ngOnInit(): void {
     this.loadClients();
@@ -84,6 +85,7 @@ export class ClientsComponent implements OnInit {
   openCreateModal(): void {
     this.modalMode = "create";
     this.form = this.getEmptyForm();
+    this.resetSerasaState();
     this.isModalOpen = true;
   }
 
@@ -97,15 +99,17 @@ export class ClientsComponent implements OnInit {
       telefone: client.telefone ?? client.phone,
       endereco: client.endereco ?? client.address,
       statusSerasa: client.statusSerasa ?? client.status,
-      debtStatus: client.debtStatus,
       ticket: client.ticket,
     };
+    this.serasaConsultedCpf = this.form.cpf;
+    this.serasaMessage = "Status recuperado do cadastro atual.";
     this.isModalOpen = true;
   }
 
   closeModal(): void {
     this.isModalOpen = false;
     this.form = this.getEmptyForm();
+    this.resetSerasaState();
   }
 
   submitForm(): void {
@@ -122,7 +126,7 @@ export class ClientsComponent implements OnInit {
       phone: this.form.telefone.trim(),
       address: this.form.endereco.trim(),
       status: this.form.statusSerasa,
-      debtStatus: this.form.debtStatus,
+      debtStatus: this.form.statusSerasa === "NEGATIVADO" ? "Bloqueado" : "Em dia",
       ticket: Number(this.form.ticket),
     };
 
@@ -130,50 +134,93 @@ export class ClientsComponent implements OnInit {
       return;
     }
 
+    if (!this.hasValidSerasaCheck()) {
+      this.showPersistenceError("Consulte o CPF no Serasa fake antes de salvar o cliente.");
+      return;
+    }
+
     if (this.modalMode === "edit" && this.form.id !== null) {
       this.clientsApiService.updateClient(normalizedClient).subscribe({
-        next: (updatedClient) => {
-          this.clients = this.clients.map((client) =>
-            client.id === this.form.id ? updatedClient : client,
-          );
+        next: () => {
           this.closeModal();
+          this.loadClients();
         },
-        error: () => this.saveClientLocally(normalizedClient),
+        error: () => this.showPersistenceError("Nao foi possivel atualizar o cliente na API."),
       });
     } else {
       this.clientsApiService.createClient(normalizedClient).subscribe({
-        next: (createdClient) => {
-          this.clients = [createdClient, ...this.clients];
+        next: () => {
           this.closeModal();
+          this.loadClients();
         },
-        error: () => this.saveClientLocally(normalizedClient),
+        error: () => this.showPersistenceError("Nao foi possivel cadastrar o cliente na API."),
       });
     }
   }
 
   deleteClient(clientId: number): void {
     this.clientsApiService.deleteClient(clientId).subscribe({
-      next: () => this.removeClientLocally(clientId),
-      error: () => this.removeClientLocally(clientId),
+      next: () => this.loadClients(),
+      error: () => this.showPersistenceError("Nao foi possivel excluir o cliente na API."),
     });
   }
 
+  consultSerasa(): void {
+    const cpfDigits = this.form.cpf.replace(/\D/g, "");
+
+    if (cpfDigits.length !== 11) {
+      this.form.statusSerasa = "REGULAR";
+      this.serasaConsultedCpf = "";
+      this.serasaMessage = "CPF deve ter 11 digitos para consulta fake.";
+      return;
+    }
+
+    this.isConsultingSerasa = true;
+    this.serasaMessage = "Consultando status Serasa fake...";
+
+    window.setTimeout(() => {
+      const lastDigit = Number(cpfDigits.at(-1));
+      const isNegativado = [0, 3, 7].includes(lastDigit);
+
+      this.form.statusSerasa = isNegativado ? "NEGATIVADO" : "REGULAR";
+      this.serasaConsultedCpf = this.form.cpf;
+      this.serasaMessage = isNegativado
+        ? "Consulta fake retornou CPF com restricao."
+        : "Consulta fake retornou CPF regular.";
+      this.isConsultingSerasa = false;
+    }, 450);
+  }
+
+  onCpfChange(): void {
+    if (this.form.cpf !== this.serasaConsultedCpf) {
+      this.form.statusSerasa = "REGULAR";
+      this.serasaMessage = "CPF alterado. Consulte novamente antes de salvar.";
+    }
+  }
+
   private loadClients(): void {
+    console.info("[clientes] carregando lista da API");
     this.isLoading = true;
     this.errorMessage = "";
-    this.isUsingFallbackData = false;
-    this.fallbackMessage = "";
+    this.changeDetectorRef.detectChanges();
 
     this.clientsApiService.listClients().subscribe({
       next: (clients) => {
-        this.clients = clients.map((client) => this.clientsApiService.normalizeClient(client));
-        this.isLoading = false;
+        this.ngZone.run(() => {
+          this.clients = clients.map((client) => this.clientsApiService.normalizeClient(client));
+          this.isLoading = false;
+          console.info("[clientes] lista carregada", this.clients.length);
+          this.changeDetectorRef.detectChanges();
+        });
       },
       error: () => {
-        this.clients = mockClients.map((client) => this.clientsApiService.normalizeClient(client));
-        this.isUsingFallbackData = true;
-        this.fallbackMessage = "API de clientes indisponivel no momento. Exibindo dados locais para continuarmos a validacao da tela.";
-        this.isLoading = false;
+        this.ngZone.run(() => {
+          this.clients = [];
+          this.errorMessage = "API de clientes indisponivel. Nao ha fallback mockado nesta tela.";
+          this.isLoading = false;
+          console.error("[clientes] falha ao carregar lista");
+          this.changeDetectorRef.detectChanges();
+        });
       },
     });
   }
@@ -187,7 +234,6 @@ export class ClientsComponent implements OnInit {
       telefone: "",
       endereco: "",
       statusSerasa: "REGULAR",
-      debtStatus: "Em dia",
       ticket: 0,
     };
   }
@@ -206,24 +252,17 @@ export class ClientsComponent implements OnInit {
     return this.clients.reduce((max, client) => Math.max(max, client.id), 0) + 1;
   }
 
-  private saveClientLocally(client: Client): void {
-    const normalizedClient = this.clientsApiService.normalizeClient(client);
-
-    if (this.modalMode === "edit" && this.form.id !== null) {
-      this.clients = this.clients.map((currentClient) =>
-        currentClient.id === this.form.id ? normalizedClient : currentClient,
-      );
-    } else {
-      this.clients = [normalizedClient, ...this.clients];
-    }
-
-    this.isUsingFallbackData = true;
-    this.fallbackMessage =
-      "API de clientes indisponivel. Alteracao aplicada localmente para manter a validacao da tela.";
-    this.closeModal();
+  private showPersistenceError(message: string): void {
+    this.errorMessage = message;
   }
 
-  private removeClientLocally(clientId: number): void {
-    this.clients = this.clients.filter((client) => client.id !== clientId);
+  private hasValidSerasaCheck(): boolean {
+    return this.form.cpf.trim().length > 0 && this.form.cpf === this.serasaConsultedCpf;
+  }
+
+  private resetSerasaState(): void {
+    this.serasaConsultedCpf = "";
+    this.isConsultingSerasa = false;
+    this.serasaMessage = "Informe o CPF e consulte o status antes de salvar.";
   }
 }

--- a/apps/web/src/app/features/dashboard/dashboard.component.css
+++ b/apps/web/src/app/features/dashboard/dashboard.component.css
@@ -101,6 +101,9 @@
 .performance-panel {
   padding: 1.8rem 1.9rem 1.45rem;
   border-radius: 14px;
+  background:
+    radial-gradient(circle at top right, rgba(37, 99, 235, 0.08), transparent 26%),
+    linear-gradient(180deg, #ffffff, #f8fbff);
 }
 
 .performance-head {
@@ -108,7 +111,7 @@
   align-items: start;
   justify-content: space-between;
   gap: 1rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1.25rem;
 }
 
 .performance-title,
@@ -130,7 +133,7 @@
   background: transparent;
   color: #4f5d71;
   padding: 0.45rem 0.85rem;
-  border-radius: 6px;
+  border-radius: 999px;
   font-size: 0.75rem;
   font-weight: 800;
   letter-spacing: 0.08em;
@@ -139,25 +142,82 @@
 .period-btn.active {
   background: #f1f4f8;
   color: #1d2738;
+  box-shadow: inset 0 0 0 1px #d9e3ef;
+}
+
+.performance-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin-bottom: 1.3rem;
+}
+
+.performance-kpi {
+  display: grid;
+  gap: 0.3rem;
+  padding: 0.95rem 1rem;
+  border-radius: 14px;
+  background: rgba(241, 245, 249, 0.9);
+  border: 1px solid #e2e8f0;
+}
+
+.performance-kpi strong {
+  color: #122033;
+  font-size: 1rem;
+  font-weight: 900;
+}
+
+.performance-kpi-accent {
+  background: linear-gradient(135deg, #e7f8ef, #f4fbf7);
+  border-color: #cdebd9;
+}
+
+.performance-kpi-label {
+  color: #64748b;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .dashboard-chart {
-  min-height: 300px;
-  gap: 0.55rem;
-  padding-top: 0.5rem;
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  align-items: end;
+  gap: 0.9rem;
+  min-height: 320px;
+  padding: 1.2rem 0.2rem 0;
   overflow: visible;
+}
+
+.chart-grid {
+  position: absolute;
+  inset: 0 0 1.45rem 0;
+  display: grid;
+  grid-template-rows: repeat(4, 1fr);
+  pointer-events: none;
+}
+
+.chart-grid span {
+  border-top: 1px dashed #dbe5f0;
 }
 
 .bar-wrap {
   position: relative;
+  z-index: 1;
   min-width: 0;
-  flex: 1 1 0;
-  gap: 0.8rem;
+  height: 100%;
+  display: grid;
+  grid-template-rows: auto auto 1fr auto;
+  align-items: end;
+  justify-items: center;
+  gap: 0.55rem;
 }
 
 .bar-tooltip {
   position: absolute;
-  top: -2.1rem;
+  top: -2.25rem;
   left: 50%;
   transform: translateX(-50%) translateY(4px);
   opacity: 0;
@@ -177,22 +237,31 @@
   transform: translateX(-50%) translateY(0);
 }
 
+.bar-value {
+  color: #8a97ab;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
 .bar {
   width: 100%;
-  max-width: 72px;
-  border-radius: 6px 6px 0 0;
-  background: #e7edf5;
+  max-width: 56px;
+  align-self: end;
+  border-radius: 18px 18px 8px 8px;
+  background: linear-gradient(180deg, #dbe5f2, #cfd9e7);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
 }
 
 .bar.active {
-  background: #0e7a51;
+  background: linear-gradient(180deg, #21b47a, #0e7a51);
+  box-shadow: 0 14px 24px rgba(14, 122, 81, 0.18);
 }
 
 .bar-label {
-  color: #454f5f;
-  font-size: 0.74rem;
-  font-weight: 800;
-  letter-spacing: 0.04em;
+  color: #334155;
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
 }
 
 .dashboard-alerts {
@@ -283,7 +352,7 @@
   margin-top: 1.55rem;
   width: 100%;
   border: 0;
-  border-radius: 4px;
+  border-radius: 10px;
   padding: 1rem;
   background: #1dbb89;
   color: #051a1e;
@@ -396,10 +465,40 @@
   .dashboard-main {
     grid-template-columns: 1fr;
   }
+
+  .performance-summary {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 720px) {
   .dashboard-stats {
     grid-template-columns: 1fr;
+  }
+
+  .performance-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .period-switch {
+    justify-content: flex-start;
+  }
+
+  .dashboard-chart {
+    gap: 0.45rem;
+    min-height: 260px;
+  }
+
+  .bar {
+    max-width: 36px;
+  }
+
+  .bar-value {
+    font-size: 0.65rem;
+  }
+
+  .bar-label {
+    font-size: 0.7rem;
   }
 }

--- a/apps/web/src/app/features/dashboard/dashboard.component.html
+++ b/apps/web/src/app/features/dashboard/dashboard.component.html
@@ -10,12 +10,12 @@
         </div>
       </div>
       <div class="stat-value">{{ formatCurrency(overview.totalSoldToday) }}</div>
-      <div class="stat-sub"><span class="stat-up">↗ +12%</span> vs. ontem</div>
+      <div class="stat-sub"><span class="stat-up">+12%</span> vs. ontem</div>
     </article>
 
     <article class="stat-card">
       <div class="stat-top">
-        <div class="stat-label">Nº DE VENDAS</div>
+        <div class="stat-label">NUMERO DE VENDAS</div>
         <div class="stat-icon stat-icon-slate">
           <svg viewBox="0 0 24 24" fill="none">
             <path d="M4 6h2l2.2 9h8.7l2.1-6H9M10 19a1 1 0 1 0 0 2 1 1 0 0 0 0-2ZM17 19a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z" />
@@ -28,7 +28,7 @@
 
     <article class="stat-card">
       <div class="stat-top">
-        <div class="stat-label">TICKET MÉDIO</div>
+        <div class="stat-label">TICKET MEDIO</div>
         <div class="stat-icon stat-icon-slate">
           <svg viewBox="0 0 24 24" fill="none">
             <path d="M6 4h12v16H6zM9 15v-3M12 15V9M15 15v-5" />
@@ -36,7 +36,7 @@
         </div>
       </div>
       <div class="stat-value">{{ formatCurrency(overview.averageTicket) }}</div>
-      <div class="stat-sub">Por transação</div>
+      <div class="stat-sub">Por transacao</div>
     </article>
 
     <article class="stat-card stat-card-warn">
@@ -49,7 +49,7 @@
         </div>
       </div>
       <div class="stat-value">{{ overview.debtClients }}</div>
-      <div class="stat-sub stat-danger">△ Atenção necessária</div>
+      <div class="stat-sub stat-danger">Atencao necessaria</div>
     </article>
   </div>
 
@@ -63,11 +63,33 @@
 
         <div class="period-switch">
           <button class="period-btn" [class.active]="selectedPeriod === 'semana'" type="button" (click)="setPeriod('semana')">SEMANA</button>
-          <button class="period-btn" [class.active]="selectedPeriod === 'mes'" type="button" (click)="setPeriod('mes')">MÊS</button>
+          <button class="period-btn" [class.active]="selectedPeriod === 'mes'" type="button" (click)="setPeriod('mes')">MES</button>
+        </div>
+      </div>
+
+      <div class="performance-summary">
+        <div class="performance-kpi">
+          <span class="performance-kpi-label">Total no periodo</span>
+          <strong>{{ formatCurrency(chartTotal) }}</strong>
+        </div>
+        <div class="performance-kpi">
+          <span class="performance-kpi-label">Media por {{ selectedPeriod === 'semana' ? 'dia' : 'semana' }}</span>
+          <strong>{{ formatCurrency(chartAverage) }}</strong>
+        </div>
+        <div class="performance-kpi performance-kpi-accent">
+          <span class="performance-kpi-label">Melhor {{ selectedPeriod === 'semana' ? 'dia' : 'semana' }}</span>
+          <strong>{{ chartPeak.day }} · {{ formatCurrency(chartPeak.value) }}</strong>
         </div>
       </div>
 
       <div class="bar-chart dashboard-chart">
+        <div class="chart-grid" aria-hidden="true">
+          <span></span>
+          <span></span>
+          <span></span>
+          <span></span>
+        </div>
+
         <div
           *ngFor="let item of chartData; let index = index"
           class="bar-wrap"
@@ -77,6 +99,7 @@
           <div class="bar-tooltip" [class.visible]="hoveredIndex === index">
             {{ formatCurrency(item.value) }}
           </div>
+          <div class="bar-value">{{ formatCurrency(item.value) }}</div>
           <div
             class="bar"
             [class.active]="selectedPeriod === 'semana' ? item.day === 'Sab' : index === 3"
@@ -117,8 +140,8 @@
 
   <section class="table-panel latest-sales-panel">
     <div class="section-header latest-sales-head">
-      <div class="section-title latest-sales-title">ÚLTIMAS VENDAS</div>
-      <a class="history-link" routerLink="/historico">VER HISTÓRICO COMPLETO</a>
+      <div class="section-title latest-sales-title">ULTIMAS VENDAS</div>
+      <a class="history-link" routerLink="/historico">VER HISTORICO COMPLETO</a>
     </div>
 
     <table class="latest-sales-table">
@@ -144,7 +167,7 @@
             </div>
           </td>
           <td class="product-main">{{ sale.mainProduct }}</td>
-          <td><pf-status-badge [text]="sale.status === 'Pendente' ? 'FIADO' : 'CONCLUÍDA'" [tone]="sale.status === 'Pendente' ? 'warning' : 'success'" /></td>
+          <td><pf-status-badge [text]="sale.status === 'Pendente' ? 'FIADO' : 'CONCLUIDA'" [tone]="sale.status === 'Pendente' ? 'warning' : 'success'" /></td>
           <td class="sale-value">{{ formatCurrency(sale.value) }}</td>
         </tr>
       </tbody>

--- a/apps/web/src/app/features/dashboard/dashboard.component.html
+++ b/apps/web/src/app/features/dashboard/dashboard.component.html
@@ -1,4 +1,12 @@
 <div class="dashboard-page">
+  <div *ngIf="isLoading" class="panel empty-state">Carregando dashboard da API...</div>
+
+  <div *ngIf="!isLoading && errorMessage" class="panel empty-state">
+    <div>{{ errorMessage }}</div>
+    <button class="btn-secondary dashboard-retry" type="button" (click)="retry()">Tentar novamente</button>
+  </div>
+
+  <ng-container *ngIf="!isLoading && !errorMessage">
   <div class="stats-grid dashboard-stats">
     <article class="stat-card stat-card-highlight">
       <div class="stat-top">
@@ -9,8 +17,8 @@
           </svg>
         </div>
       </div>
-      <div class="stat-value">{{ formatCurrency(overview.totalSoldToday) }}</div>
-      <div class="stat-sub"><span class="stat-up">+12%</span> vs. ontem</div>
+      <div class="stat-value">{{ formatCurrency(dashboard.totalSoldToday) }}</div>
+      <div class="stat-sub"><span class="stat-up">{{ comparedToYesterdayLabel }}</span> vs. ontem</div>
     </article>
 
     <article class="stat-card">
@@ -22,7 +30,7 @@
           </svg>
         </div>
       </div>
-      <div class="stat-value">{{ overview.salesCount }}</div>
+      <div class="stat-value">{{ dashboard.salesCount }}</div>
       <div class="stat-sub">Vendas confirmadas</div>
     </article>
 
@@ -35,7 +43,7 @@
           </svg>
         </div>
       </div>
-      <div class="stat-value">{{ formatCurrency(overview.averageTicket) }}</div>
+      <div class="stat-value">{{ formatCurrency(dashboard.averageTicket) }}</div>
       <div class="stat-sub">Por transacao</div>
     </article>
 
@@ -48,7 +56,7 @@
           </svg>
         </div>
       </div>
-      <div class="stat-value">{{ overview.debtClients }}</div>
+      <div class="stat-value">{{ dashboard.debtClients }}</div>
       <div class="stat-sub stat-danger">Atencao necessaria</div>
     </article>
   </div>
@@ -114,7 +122,7 @@
       <div class="alerts-title">PAINEL DE ALERTAS</div>
 
       <div class="alert-list">
-        <div *ngFor="let alert of alerts; let index = index" class="alert-item" [class.alert-red]="index === 1" [class.alert-yellow]="index === 0" [class.alert-orange]="index === 2">
+        <div *ngFor="let alert of alerts; let index = index" class="alert-item" [class.alert-red]="alert.tone === 'red'" [class.alert-yellow]="alert.tone === 'yellow'" [class.alert-orange]="alert.tone === 'orange'">
           <div class="alert-side"></div>
           <div class="alert-icon">
             <svg *ngIf="index === 0" viewBox="0 0 24 24" fill="none">
@@ -134,7 +142,7 @@
         </div>
       </div>
 
-      <button class="btn-resolve-dashboard" type="button">RESOLVER TUDO</button>
+    <a class="btn-resolve-dashboard" routerLink="/fiado">VER PENDENCIAS</a>
     </aside>
   </div>
 
@@ -175,4 +183,5 @@
 
     <button class="floating-sale-btn" type="button" aria-label="Nova venda">+</button>
   </section>
+  </ng-container>
 </div>

--- a/apps/web/src/app/features/dashboard/dashboard.component.ts
+++ b/apps/web/src/app/features/dashboard/dashboard.component.ts
@@ -1,10 +1,17 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { ChangeDetectorRef, Component, NgZone, OnInit } from "@angular/core";
 import { RouterLink } from "@angular/router";
-import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
-import { alerts, overview, weeklySales } from "../../core/mock-data";
-import { StorageService } from "../../core/services/storage.service";
+import { Sale } from "../../core/models";
+import { DashboardReport, DailySalesReport, ReportsApiService } from "../../core/services/reports-api.service";
+import { SalesApiService } from "../../core/services/sales-api.service";
 import { formatCurrency } from "../../core/utils/format";
+import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
+
+type DashboardAlert = {
+  title: string;
+  body: string;
+  tone: "yellow" | "red" | "orange";
+};
 
 @Component({
   selector: "pf-dashboard",
@@ -13,31 +20,62 @@ import { formatCurrency } from "../../core/utils/format";
   templateUrl: "./dashboard.component.html",
   styleUrl: "./dashboard.component.css"
 })
-export class DashboardComponent {
-  readonly alerts = alerts;
-  readonly overview = overview;
-  readonly weeklySales = weeklySales;
-  readonly sales = this.storageService.getSales();
+export class DashboardComponent implements OnInit {
+  dashboard: DashboardReport = {
+    totalSoldToday: 0,
+    salesCount: 0,
+    averageTicket: 0,
+    debtClients: 0,
+    comparedToYesterday: 0,
+  };
+  weekSales: DailySalesReport[] = [];
+  monthSales: DailySalesReport[] = [];
+  sales: Sale[] = [];
+  isLoading = true;
+  errorMessage = "";
   readonly formatCurrency = formatCurrency;
-  readonly monthlySales = [
-    { day: "S1", value: 4120 },
-    { day: "S2", value: 5380 },
-    { day: "S3", value: 4860 },
-    { day: "S4", value: 6210 }
-  ];
   selectedPeriod: "semana" | "mes" = "semana";
   hoveredIndex: number | null = null;
 
-  constructor(private readonly storageService: StorageService) {}
+  constructor(
+    private readonly reportsApiService: ReportsApiService,
+    private readonly salesApiService: SalesApiService,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly ngZone: NgZone,
+  ) {}
 
-  get chartData() {
-    return this.selectedPeriod === "semana" ? this.weeklySales : this.monthlySales;
+  ngOnInit(): void {
+    this.loadDashboard();
+  }
+
+  get alerts(): DashboardAlert[] {
+    return [
+      {
+        title: "Fiado em aberto",
+        body: `${this.dashboard.debtClients} cliente(s) com saldo de fiado pendente.`,
+        tone: this.dashboard.debtClients > 0 ? "yellow" : "orange",
+      },
+      {
+        title: "Vendas canceladas",
+        body: "Acompanhe cancelamentos pela tela de historico ate criarmos acao dedicada.",
+        tone: "red",
+      },
+      {
+        title: "Autenticacao pendente",
+        body: "Nova venda ainda usa funcionario fixo ate JWT retornar o operador logado.",
+        tone: "orange",
+      },
+    ];
+  }
+
+  get chartData(): DailySalesReport[] {
+    return this.selectedPeriod === "semana" ? this.weekSales : this.monthSales;
   }
 
   get chartSubtitle(): string {
     return this.selectedPeriod === "semana"
       ? "Vendas dos ultimos 7 dias"
-      : "Vendas consolidadas nas ultimas 4 semanas";
+      : "Vendas consolidadas dos ultimos 30 dias";
   }
 
   get chartTotal(): number {
@@ -52,10 +90,24 @@ export class DashboardComponent {
     return Number((this.chartTotal / this.chartData.length).toFixed(2));
   }
 
-  get chartPeak() {
+  get chartPeak(): DailySalesReport {
+    if (!this.chartData.length) {
+      return { date: "", day: "-", value: 0, orders: 0 };
+    }
+
     return this.chartData.reduce((highest, current) =>
       current.value > highest.value ? current : highest,
     );
+  }
+
+  get comparedToYesterdayLabel(): string {
+    const value = this.dashboard.comparedToYesterday;
+
+    return `${value >= 0 ? "+" : ""}${value.toFixed(0)}%`;
+  }
+
+  retry(): void {
+    this.loadDashboard();
   }
 
   setPeriod(period: "semana" | "mes"): void {
@@ -68,7 +120,7 @@ export class DashboardComponent {
   }
 
   getBarHeight(value: number): number {
-    const max = Math.max(...this.chartData.map((item) => item.value));
+    const max = Math.max(...this.chartData.map((item) => item.value), 1);
     const normalized = (value / max) * 220;
     return normalized < 72 ? 72 : normalized;
   }
@@ -80,5 +132,86 @@ export class DashboardComponent {
       .slice(0, 2)
       .map((part) => part[0]?.toUpperCase() ?? "")
       .join("");
+  }
+
+  private loadDashboard(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.changeDetectorRef.detectChanges();
+
+    let pending = 4;
+    let hasFailure = false;
+
+    const finish = () => {
+      pending -= 1;
+
+      if (pending === 0) {
+        this.ngZone.run(() => {
+          this.isLoading = false;
+
+          if (hasFailure) {
+            this.errorMessage = "API do dashboard indisponivel. Nao ha fallback mockado nesta tela.";
+          }
+
+          this.changeDetectorRef.detectChanges();
+        });
+      }
+    };
+
+    this.reportsApiService.getDashboardReport().subscribe({
+      next: (dashboard) => {
+        this.dashboard = dashboard;
+        finish();
+      },
+      error: () => {
+        hasFailure = true;
+        finish();
+      },
+    });
+
+    this.reportsApiService.getSalesReport(this.getDateRange(6)).subscribe({
+      next: (report) => {
+        this.weekSales = report.dailySales;
+        finish();
+      },
+      error: () => {
+        hasFailure = true;
+        finish();
+      },
+    });
+
+    this.reportsApiService.getSalesReport(this.getDateRange(29)).subscribe({
+      next: (report) => {
+        this.monthSales = report.dailySales;
+        finish();
+      },
+      error: () => {
+        hasFailure = true;
+        finish();
+      },
+    });
+
+    this.salesApiService.listSales({ page: 1, limit: 3 }).subscribe({
+      next: (response) => {
+        this.sales = response.data;
+        finish();
+      },
+      error: () => {
+        hasFailure = true;
+        finish();
+      },
+    });
+  }
+
+  private getDateRange(daysBack: number): { dataInicio: string; dataFim: string } {
+    const end = new Date();
+    const start = new Date();
+
+    start.setDate(start.getDate() - daysBack);
+
+    return {
+      dataInicio: start.toISOString().slice(0, 10),
+      dataFim: end.toISOString().slice(0, 10),
+    };
   }
 }

--- a/apps/web/src/app/features/dashboard/dashboard.component.ts
+++ b/apps/web/src/app/features/dashboard/dashboard.component.ts
@@ -40,6 +40,24 @@ export class DashboardComponent {
       : "Vendas consolidadas nas ultimas 4 semanas";
   }
 
+  get chartTotal(): number {
+    return this.chartData.reduce((sum, item) => sum + item.value, 0);
+  }
+
+  get chartAverage(): number {
+    if (!this.chartData.length) {
+      return 0;
+    }
+
+    return Number((this.chartTotal / this.chartData.length).toFixed(2));
+  }
+
+  get chartPeak() {
+    return this.chartData.reduce((highest, current) =>
+      current.value > highest.value ? current : highest,
+    );
+  }
+
   setPeriod(period: "semana" | "mes"): void {
     this.selectedPeriod = period;
     this.hoveredIndex = null;
@@ -51,8 +69,8 @@ export class DashboardComponent {
 
   getBarHeight(value: number): number {
     const max = Math.max(...this.chartData.map((item) => item.value));
-    const normalized = (value / max) * 255;
-    return normalized < 64 ? 64 : normalized;
+    const normalized = (value / max) * 220;
+    return normalized < 72 ? 72 : normalized;
   }
 
   getInitials(name: string): string {

--- a/apps/web/src/app/features/debts/debts.component.css
+++ b/apps/web/src/app/features/debts/debts.component.css
@@ -32,3 +32,7 @@
   color: var(--text-muted);
   line-height: 1.55;
 }
+
+.retry-button {
+  margin-top: 1rem;
+}

--- a/apps/web/src/app/features/debts/debts.component.html
+++ b/apps/web/src/app/features/debts/debts.component.html
@@ -18,18 +18,20 @@
     <div *ngIf="isLoading" class="empty-state">Carregando carteira de fiado...</div>
 
     <div *ngIf="!isLoading && errorMessage" class="empty-state">
-      {{ errorMessage }}
+      <div>{{ errorMessage }}</div>
+      <button class="btn-secondary retry-button" type="button" (click)="retry()">Tentar novamente</button>
     </div>
 
     <div *ngFor="let debtor of debtors" class="debtor-row">
       <div>
         <div class="client-name">{{ getClientName(debtor.clientId) }}</div>
         <div class="client-time">{{ debtor.phone || debtor.overdue }}</div>
+        <div class="client-time">{{ debtor.lastPurchase }}</div>
       </div>
       <div class="debtor-value" [class.critical]="debtor.status === 'Critico'">{{ formatCurrency(debtor.amount) }}</div>
       <div class="debtor-meta-ok">{{ debtor.overdue }}</div>
       <div><pf-status-badge [text]="debtor.status" /></div>
-      <button class="btn-cobrar" type="button">Cobrar</button>
+      <button class="btn-cobrar" type="button" (click)="chargeDebtor(debtor.clientId)">Cobrar</button>
     </div>
 
     <div *ngIf="!isLoading && debtors.length === 0" class="empty-state">Nenhum cliente com saldo de fiado em aberto.</div>

--- a/apps/web/src/app/features/debts/debts.component.html
+++ b/apps/web/src/app/features/debts/debts.component.html
@@ -9,22 +9,30 @@
 <div class="fiado-stats">
   <div class="stat-card"><div class="stat-label">Total em aberto</div><div class="stat-value">{{ formatCurrency(totalDebt) }}</div></div>
   <div class="stat-card"><div class="stat-label">Recuperado no mes</div><div class="stat-value">{{ formatCurrency(5120) }}</div></div>
-  <div class="stat-card"><div class="stat-label">Clientes inadimplentes</div><div class="stat-value">42</div></div>
+  <div class="stat-card"><div class="stat-label">Clientes inadimplentes</div><div class="stat-value">{{ overdueClientsCount }}</div></div>
   <div class="stat-card"><div class="stat-label">Status da carteira</div><div class="stat-value">Atencao</div></div>
 </div>
 
 <div class="row col-2">
   <div class="table-panel debtors-panel">
+    <div *ngIf="isLoading" class="empty-state">Carregando carteira de fiado...</div>
+
+    <div *ngIf="!isLoading && isUsingFallbackData" class="empty-state">
+      {{ fallbackMessage }}
+    </div>
+
     <div *ngFor="let debtor of debtors" class="debtor-row">
       <div>
         <div class="client-name">{{ getClientName(debtor.clientId) }}</div>
-        <div class="client-time">{{ debtor.overdue }}</div>
+        <div class="client-time">{{ debtor.phone || debtor.overdue }}</div>
       </div>
       <div class="debtor-value" [class.critical]="debtor.status === 'Critico'">{{ formatCurrency(debtor.amount) }}</div>
-      <div class="debtor-meta-ok">Ultima compra {{ debtor.lastPurchase }}</div>
+      <div class="debtor-meta-ok">{{ debtor.overdue }}</div>
       <div><pf-status-badge [text]="debtor.status" /></div>
       <button class="btn-cobrar" type="button">Cobrar</button>
     </div>
+
+    <div *ngIf="!isLoading && debtors.length === 0" class="empty-state">Nenhum cliente com saldo de fiado em aberto.</div>
   </div>
 
   <div class="tip-card">

--- a/apps/web/src/app/features/debts/debts.component.html
+++ b/apps/web/src/app/features/debts/debts.component.html
@@ -17,8 +17,8 @@
   <div class="table-panel debtors-panel">
     <div *ngIf="isLoading" class="empty-state">Carregando carteira de fiado...</div>
 
-    <div *ngIf="!isLoading && isUsingFallbackData" class="empty-state">
-      {{ fallbackMessage }}
+    <div *ngIf="!isLoading && errorMessage" class="empty-state">
+      {{ errorMessage }}
     </div>
 
     <div *ngFor="let debtor of debtors" class="debtor-row">

--- a/apps/web/src/app/features/debts/debts.component.ts
+++ b/apps/web/src/app/features/debts/debts.component.ts
@@ -1,7 +1,6 @@
 import { CommonModule } from "@angular/common";
 import { Component, OnInit } from "@angular/core";
 import { Client, Debtor } from "../../core/models";
-import { clients, debtors } from "../../core/mock-data";
 import { ClientsApiService } from "../../core/services/clients-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 import { formatCurrency } from "../../core/utils/format";
@@ -17,8 +16,7 @@ export class DebtsComponent implements OnInit {
   debtors: Debtor[] = [];
   clients: Client[] = [];
   isLoading = true;
-  isUsingFallbackData = false;
-  fallbackMessage = "";
+  errorMessage = "";
   readonly formatCurrency = formatCurrency;
 
   constructor(private readonly clientsApiService: ClientsApiService) {}
@@ -43,8 +41,7 @@ export class DebtsComponent implements OnInit {
 
   private loadFiadoFromClients(): void {
     this.isLoading = true;
-    this.isUsingFallbackData = false;
-    this.fallbackMessage = "";
+    this.errorMessage = "";
 
     this.clientsApiService.listClients().subscribe({
       next: (apiClients) => {
@@ -53,11 +50,9 @@ export class DebtsComponent implements OnInit {
         this.isLoading = false;
       },
       error: () => {
-        this.clients = clients.map((client) => this.clientsApiService.normalizeClient(client));
-        this.debtors = debtors;
-        this.isUsingFallbackData = true;
-        this.fallbackMessage =
-          "API de clientes indisponivel. Carteira de fiado exibida com dados mockados ate existir a rota dedicada de fiado.";
+        this.clients = [];
+        this.debtors = [];
+        this.errorMessage = "API de clientes indisponivel. Nao ha fallback mockado para carteira de fiado.";
         this.isLoading = false;
       },
     });

--- a/apps/web/src/app/features/debts/debts.component.ts
+++ b/apps/web/src/app/features/debts/debts.component.ts
@@ -1,6 +1,8 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
+import { Client, Debtor } from "../../core/models";
 import { clients, debtors } from "../../core/mock-data";
+import { ClientsApiService } from "../../core/services/clients-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 import { formatCurrency } from "../../core/utils/format";
 
@@ -11,16 +13,71 @@ import { formatCurrency } from "../../core/utils/format";
   templateUrl: "./debts.component.html",
   styleUrl: "./debts.component.css"
 })
-export class DebtsComponent {
-  readonly debtors = debtors;
-  readonly clients = clients;
+export class DebtsComponent implements OnInit {
+  debtors: Debtor[] = [];
+  clients: Client[] = [];
+  isLoading = true;
+  isUsingFallbackData = false;
+  fallbackMessage = "";
   readonly formatCurrency = formatCurrency;
+
+  constructor(private readonly clientsApiService: ClientsApiService) {}
+
+  ngOnInit(): void {
+    this.loadFiadoFromClients();
+  }
 
   get totalDebt(): number {
     return this.debtors.reduce((sum, debtor) => sum + debtor.amount, 0);
   }
 
+  get overdueClientsCount(): number {
+    return this.debtors.length;
+  }
+
   getClientName(clientId: number): string {
-    return this.clients.find((client) => client.id === clientId)?.name ?? "Cliente";
+    const debtor = this.debtors.find((item) => item.clientId === clientId);
+
+    return debtor?.clientName ?? this.clients.find((client) => client.id === clientId)?.nome ?? "Cliente";
+  }
+
+  private loadFiadoFromClients(): void {
+    this.isLoading = true;
+    this.isUsingFallbackData = false;
+    this.fallbackMessage = "";
+
+    this.clientsApiService.listClients().subscribe({
+      next: (apiClients) => {
+        this.clients = apiClients;
+        this.debtors = this.buildDebtorsFromClients(apiClients);
+        this.isLoading = false;
+      },
+      error: () => {
+        this.clients = clients.map((client) => this.clientsApiService.normalizeClient(client));
+        this.debtors = debtors;
+        this.isUsingFallbackData = true;
+        this.fallbackMessage =
+          "API de clientes indisponivel. Carteira de fiado exibida com dados mockados ate existir a rota dedicada de fiado.";
+        this.isLoading = false;
+      },
+    });
+  }
+
+  private buildDebtorsFromClients(apiClients: Client[]): Debtor[] {
+    return apiClients
+      .filter((client) => Number(client.contaFiado?.saldoDevedor ?? 0) > 0)
+      .map((client) => ({
+        clientId: client.id,
+        clientName: client.nome ?? client.name,
+        phone: client.telefone ?? client.phone,
+        amount: Number(client.contaFiado?.saldoDevedor ?? 0),
+        overdue: client.contaFiado?.dataUltimaCobranca
+          ? `Ultima cobranca em ${new Date(client.contaFiado.dataUltimaCobranca).toLocaleDateString("pt-BR")}`
+          : "Sem cobranca registrada",
+        status: client.statusSerasa === "NEGATIVADO" ? "Critico" : "Fiado ativo",
+        lastPurchase: "Aguardando historico de vendas",
+        lastInstallment: 0,
+        statusNotificacao: client.contaFiado?.statusNotificacao ?? "NENHUMA",
+      }));
   }
 }

--- a/apps/web/src/app/features/debts/debts.component.ts
+++ b/apps/web/src/app/features/debts/debts.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { Component, OnInit } from "@angular/core";
-import { Client, Debtor } from "../../core/models";
-import { ClientsApiService } from "../../core/services/clients-api.service";
+import { Debtor } from "../../core/models";
+import { FiadoApiService } from "../../core/services/fiado-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 import { formatCurrency } from "../../core/utils/format";
 
@@ -14,15 +14,14 @@ import { formatCurrency } from "../../core/utils/format";
 })
 export class DebtsComponent implements OnInit {
   debtors: Debtor[] = [];
-  clients: Client[] = [];
   isLoading = true;
   errorMessage = "";
   readonly formatCurrency = formatCurrency;
 
-  constructor(private readonly clientsApiService: ClientsApiService) {}
+  constructor(private readonly fiadoApiService: FiadoApiService) {}
 
   ngOnInit(): void {
-    this.loadFiadoFromClients();
+    this.loadDebtors();
   }
 
   get totalDebt(): number {
@@ -36,43 +35,38 @@ export class DebtsComponent implements OnInit {
   getClientName(clientId: number): string {
     const debtor = this.debtors.find((item) => item.clientId === clientId);
 
-    return debtor?.clientName ?? this.clients.find((client) => client.id === clientId)?.nome ?? "Cliente";
+    return debtor?.clientName ?? "Cliente";
   }
 
-  private loadFiadoFromClients(): void {
-    this.isLoading = true;
-    this.errorMessage = "";
+  retry(): void {
+    this.loadDebtors();
+  }
 
-    this.clientsApiService.listClients().subscribe({
-      next: (apiClients) => {
-        this.clients = apiClients;
-        this.debtors = this.buildDebtorsFromClients(apiClients);
-        this.isLoading = false;
+  chargeDebtor(clientId: number): void {
+    this.fiadoApiService.registerCharge(clientId).subscribe({
+      next: (updatedDebtor) => {
+        this.debtors = this.debtors.map((debtor) => (debtor.clientId === clientId ? updatedDebtor : debtor));
       },
       error: () => {
-        this.clients = [];
-        this.debtors = [];
-        this.errorMessage = "API de clientes indisponivel. Nao ha fallback mockado para carteira de fiado.";
-        this.isLoading = false;
+        this.errorMessage = "Nao foi possivel registrar cobranca na API.";
       },
     });
   }
 
-  private buildDebtorsFromClients(apiClients: Client[]): Debtor[] {
-    return apiClients
-      .filter((client) => Number(client.contaFiado?.saldoDevedor ?? 0) > 0)
-      .map((client) => ({
-        clientId: client.id,
-        clientName: client.nome ?? client.name,
-        phone: client.telefone ?? client.phone,
-        amount: Number(client.contaFiado?.saldoDevedor ?? 0),
-        overdue: client.contaFiado?.dataUltimaCobranca
-          ? `Ultima cobranca em ${new Date(client.contaFiado.dataUltimaCobranca).toLocaleDateString("pt-BR")}`
-          : "Sem cobranca registrada",
-        status: client.statusSerasa === "NEGATIVADO" ? "Critico" : "Fiado ativo",
-        lastPurchase: "Aguardando historico de vendas",
-        lastInstallment: 0,
-        statusNotificacao: client.contaFiado?.statusNotificacao ?? "NENHUMA",
-      }));
+  private loadDebtors(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+
+    this.fiadoApiService.listDebtors().subscribe({
+      next: (apiDebtors) => {
+        this.debtors = apiDebtors;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.debtors = [];
+        this.errorMessage = "API de fiado indisponivel. Nao ha fallback mockado para carteira de fiado.";
+        this.isLoading = false;
+      },
+    });
   }
 }

--- a/apps/web/src/app/features/employees/employees.component.css
+++ b/apps/web/src/app/features/employees/employees.component.css
@@ -1,61 +1,231 @@
 :host {
-  display: grid;
-  gap: 1rem;
+  display: block;
 }
 
-.employee-card {
-  padding: 1.2rem;
+.employees-page {
+  position: relative;
 }
 
-.employee-header {
-  display: flex;
+.employees-header {
+  align-items: start;
+}
+
+.employees-title {
+  font-size: 1.2rem;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+}
+
+.btn-new-employee {
+  display: inline-flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.6rem;
+  border: 0;
+  border-radius: 8px;
+  padding: 1rem 1.2rem;
+  background: #162236;
+  color: #ffffff;
+  font-size: 0.95rem;
+  font-weight: 700;
+  box-shadow: 0 10px 20px rgba(22, 34, 54, 0.18);
+}
+
+.btn-new-icon {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  border: 1.5px solid rgba(255, 255, 255, 0.8);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.stats-row {
   margin-bottom: 1rem;
 }
 
-.employee-avatar {
-  position: relative;
-  width: 56px;
-  height: 56px;
-  display: grid;
-  place-items: center;
-  border-radius: 18px;
-  background: #e0f2e8;
-  color: var(--green-dark);
+.stat-row-item {
+  padding: 1rem 1.1rem;
+  border-radius: 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.stat-row-label {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.stat-row-value {
+  margin-top: 0.45rem;
+  font-size: 1.4rem;
   font-weight: 800;
 }
 
-.employee-online {
-  position: absolute;
-  right: 4px;
-  bottom: 4px;
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: var(--green-light);
-  border: 2px solid #fff;
+.employee-search-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  margin: 0 0 1rem;
+}
+
+.employee-search-row .search-bar {
+  margin: 0;
+}
+
+.retry-button {
+  margin-top: 1rem;
+}
+
+.employee-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.employee-avatar {
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  background: #e0f2e8;
+  color: var(--green-dark);
+  font-weight: 800;
 }
 
 .employee-name {
   font-weight: 800;
 }
 
-.employee-role,
-.employee-id,
-.emp-stat-label {
+.employee-id {
   color: var(--text-muted);
+  font-size: 0.82rem;
 }
 
-.emp-stat {
-  padding: 1rem;
-  border-radius: 12px;
-  background: var(--surface-muted);
-  border: 1px solid var(--border);
+.employee-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
 }
 
-.emp-stat-value {
-  margin-top: 0.4rem;
+.icon-action {
+  width: 26px;
+  height: 26px;
+  border: 0;
+  background: transparent;
+  color: #90a0b8;
+  padding: 0;
+}
+
+.icon-action svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  stroke-width: 1.9;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.employee-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(4px);
+}
+
+.employee-modal {
+  width: min(100%, 760px);
+  max-height: min(90vh, 820px);
+  border-radius: 16px;
+  background: #ffffff;
+  border: 1px solid #e5ebf3;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+  overflow: hidden;
+}
+
+.employee-modal-head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.3rem 1.4rem 1rem;
+  border-bottom: 1px solid #eef2f7;
+}
+
+.employee-modal-title {
+  color: #162236;
   font-size: 1.1rem;
   font-weight: 800;
+}
+
+.employee-modal-subtitle {
+  margin-top: 0.25rem;
+  color: #8290a6;
+  font-size: 0.88rem;
+}
+
+.modal-close {
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 10px;
+  background: #f3f6fa;
+  color: #5d6d84;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.employee-form {
+  display: grid;
+  gap: 1.2rem;
+  max-height: calc(90vh - 94px);
+  overflow-y: auto;
+  padding: 1.25rem 1.4rem 1.4rem;
+}
+
+.employee-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.employee-form-full {
+  grid-column: 1 / -1;
+}
+
+.employee-modal-actions {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.8rem;
+  padding-top: 0.4rem;
+  background: #ffffff;
+}
+
+@media (max-width: 900px) {
+  .table-panel {
+    overflow-x: auto;
+  }
+
+  .table-panel table {
+    min-width: 980px;
+  }
+}
+
+@media (max-width: 720px) {
+  .employee-search-row {
+    grid-template-columns: 1fr;
+  }
+
+  .employee-form-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/apps/web/src/app/features/employees/employees.component.html
+++ b/apps/web/src/app/features/employees/employees.component.html
@@ -1,40 +1,182 @@
-<div class="page-header">
-  <div>
-    <div class="page-title">Funcionarios</div>
-    <div class="page-subtitle">Dados pessoais, presenca, ferias e visao rapida do quadro operacional.</div>
-  </div>
-  <button class="btn-primary" type="button">Novo funcionario</button>
-</div>
-
-<article *ngFor="let employee of employees" class="employee-card">
-  <div class="employee-header">
-    <div class="employee-avatar">
-      {{ employee.name.slice(0, 1) }}
-      <div class="employee-online"></div>
+<div class="employees-page">
+  <div class="page-header employees-header">
+    <div>
+      <div class="page-title employees-title">Gestao de funcionarios</div>
+      <div class="page-subtitle">Cadastro operacional, perfil de acesso, ponto, ferias e documentos vinculados.</div>
     </div>
-    <div class="flex-1">
-      <div class="employee-name">{{ employee.name }}</div>
-      <div class="employee-role">{{ employee.role }}</div>
-      <div class="employee-id">ID {{ employee.id }}</div>
+    <button class="btn-new-employee" type="button" (click)="openCreateModal()">
+      <span class="btn-new-icon">+</span>
+      <span>Novo funcionario</span>
+    </button>
+  </div>
+
+  <div class="stats-row">
+    <div class="stat-row-item"><div class="stat-row-label">Total de funcionarios</div><div class="stat-row-value">{{ totalEmployees }}</div></div>
+    <div class="stat-row-item"><div class="stat-row-label">Ativos</div><div class="stat-row-value green">{{ activeEmployees }}</div></div>
+    <div class="stat-row-item"><div class="stat-row-label">Com ponto</div><div class="stat-row-value">{{ attendanceRegistered }}</div></div>
+    <div class="stat-row-item"><div class="stat-row-label">Ferias registradas</div><div class="stat-row-value">{{ vacationRecords }}</div></div>
+  </div>
+
+  <div class="employee-search-row">
+    <input
+      class="search-bar"
+      type="text"
+      placeholder="Buscar por nome, CPF, matricula, e-mail ou cargo..."
+      [(ngModel)]="query"
+      (keyup.enter)="searchEmployees()"
+    />
+    <button class="btn-secondary" type="button" (click)="searchEmployees()">Buscar</button>
+  </div>
+
+  <div class="table-panel">
+    <div *ngIf="isLoading" class="empty-state">Carregando funcionarios da API...</div>
+
+    <div *ngIf="!isLoading && errorMessage" class="empty-state">
+      <div>{{ errorMessage }}</div>
+      <button class="btn-secondary retry-button" type="button" (click)="retry()">Tentar novamente</button>
     </div>
-    <pf-status-badge [text]="employee.status" />
+
+    <table>
+      <thead *ngIf="!isLoading && !errorMessage">
+        <tr>
+          <th>Funcionario</th>
+          <th>Matricula</th>
+          <th>CPF</th>
+          <th>Contato</th>
+          <th>Cargo</th>
+          <th>Perfil</th>
+          <th>Admissao</th>
+          <th>Status</th>
+          <th>Acoes</th>
+        </tr>
+      </thead>
+      <tbody *ngIf="!isLoading && !errorMessage">
+        <tr *ngFor="let employee of filteredEmployees">
+          <td>
+            <div class="employee-cell">
+              <div class="employee-avatar">{{ (employee.nome || employee.name).slice(0, 1) }}</div>
+              <div>
+                <div class="employee-name">{{ employee.nome || employee.name }}</div>
+                <div class="employee-id">{{ employee.email || "Sem e-mail" }}</div>
+              </div>
+            </div>
+          </td>
+          <td>{{ employee.matricula || "Nao informado" }}</td>
+          <td>{{ employee.cpf || "Nao informado" }}</td>
+          <td>
+            <div>{{ employee.telefone || "Nao informado" }}</div>
+            <div class="employee-id">{{ employee.contatoEmergencia || "Sem emergencia" }}</div>
+          </td>
+          <td>{{ employee.cargo || employee.role }}</td>
+          <td>{{ formatRole(employee.accessRole) }}</td>
+          <td>{{ employee.admission }}</td>
+          <td><pf-status-badge [text]="employee.status" /></td>
+          <td>
+            <div class="employee-actions">
+              <button class="icon-action" type="button" aria-label="Editar funcionario" (click)="openEditModal(employee)">
+                <svg viewBox="0 0 24 24" fill="none">
+                  <path d="M4 20h4l10-10-4-4L4 16v4ZM13 7l4 4" />
+                </svg>
+              </button>
+              <button class="icon-action" type="button" aria-label="Excluir funcionario" (click)="deleteEmployee(employee.id)">
+                <svg viewBox="0 0 24 24" fill="none">
+                  <path d="M5 7h14M9 7V4h6v3M8 10v7M12 10v7M16 10v7M7 7l1 13h8l1-13" />
+                </svg>
+              </button>
+            </div>
+          </td>
+        </tr>
+        <tr *ngIf="filteredEmployees.length === 0">
+          <td colspan="9" class="empty-state">Nenhum funcionario encontrado.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div *ngIf="!isLoading && !errorMessage" class="table-footer">
+      <span>Exibindo {{ filteredEmployees.length }} de {{ totalItems }} funcionarios</span>
+      <div class="pagination">
+        <button class="page-btn" type="button" [disabled]="currentPage <= 1" (click)="previousPage()">Anterior</button>
+        <button class="page-btn active" type="button">{{ currentPage }} / {{ totalPages }}</button>
+        <button class="page-btn" type="button" [disabled]="currentPage >= totalPages" (click)="nextPage()">Proxima</button>
+      </div>
+    </div>
   </div>
 
-  <div class="employee-stats">
-    <div class="emp-stat"><div class="emp-stat-label">Horas mensais</div><div class="emp-stat-value">{{ employee.monthlyHours }}</div></div>
-    <div class="emp-stat"><div class="emp-stat-label">Horas extras</div><div class="emp-stat-value">{{ employee.overtime }}</div></div>
-    <div class="emp-stat"><div class="emp-stat-label">Saldo de ferias</div><div class="emp-stat-value">{{ employee.vacationBalance }}</div></div>
-    <div class="emp-stat"><div class="emp-stat-label">Assiduidade</div><div class="emp-stat-value">{{ employee.attendance }}</div></div>
-  </div>
-</article>
+  <div *ngIf="isModalOpen" class="employee-modal-backdrop" (click)="closeModal()">
+    <div class="employee-modal" (click)="$event.stopPropagation()">
+      <div class="employee-modal-head">
+        <div>
+          <div class="employee-modal-title">{{ modalMode === 'edit' ? 'Editar funcionario' : 'Novo funcionario' }}</div>
+          <div class="employee-modal-subtitle">A tela segue o contrato do backend. O backend recebe senha e grava somente o hash.</div>
+        </div>
+        <button class="modal-close" type="button" (click)="closeModal()">x</button>
+      </div>
 
-<div class="panel">
-  <div class="panel-title">Novo funcionario</div>
-  <div class="panel-sub">Formulario base para padronizar o cadastro no novo frontend Angular.</div>
-  <div class="form-grid">
-    <div class="form-group"><label class="form-label">Nome completo</label><input class="form-input" placeholder="Ex: Joao da Silva" /></div>
-    <div class="form-group"><label class="form-label">CPF</label><input class="form-input" placeholder="000.000.000-00" /></div>
-    <div class="form-group"><label class="form-label">Telefone</label><input class="form-input" placeholder="(00) 00000-0000" /></div>
-    <div class="form-group"><label class="form-label">Cargo</label><select class="form-select"><option>Padeiro</option><option>Caixa</option><option>Supervisor</option></select></div>
+      <form class="employee-form" (ngSubmit)="submitForm()">
+        <div class="employee-form-grid">
+          <div class="form-group">
+            <label class="form-label">Nome completo</label>
+            <input class="form-input" name="nome" [(ngModel)]="form.nome" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">CPF</label>
+            <input class="form-input" name="cpf" [(ngModel)]="form.cpf" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Telefone</label>
+            <input class="form-input" name="telefone" [(ngModel)]="form.telefone" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Endereco</label>
+            <input class="form-input" name="endereco" [(ngModel)]="form.endereco" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Matricula</label>
+            <input class="form-input" name="matricula" [(ngModel)]="form.matricula" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Cargo</label>
+            <input class="form-input" name="cargo" [(ngModel)]="form.cargo" placeholder="Ex: Caixa, Padeiro, Supervisor" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Data de admissao</label>
+            <input class="form-input" name="dataAdmissao" type="date" [(ngModel)]="form.dataAdmissao" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Contato de emergencia</label>
+            <input class="form-input" name="contatoEmergencia" [(ngModel)]="form.contatoEmergencia" required />
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">Perfil de acesso</label>
+            <select class="form-select" name="role" [(ngModel)]="form.role" required>
+              <option *ngFor="let role of roles" [ngValue]="role">{{ formatRole(role) }}</option>
+            </select>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">E-mail</label>
+            <input class="form-input" name="email" type="email" [(ngModel)]="form.email" required />
+          </div>
+
+          <div class="form-group employee-form-full">
+            <label class="form-label">Senha {{ modalMode === 'edit' ? '(preencha somente para trocar)' : '' }}</label>
+            <input class="form-input" name="senha" type="password" [(ngModel)]="form.senha" [required]="modalMode === 'create'" />
+          </div>
+        </div>
+
+        <div class="employee-modal-actions">
+          <button class="btn-secondary" type="button" (click)="closeModal()">Cancelar</button>
+          <button class="btn-primary" type="submit">{{ modalMode === 'edit' ? 'Salvar alteracoes' : 'Cadastrar funcionario' }}</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>

--- a/apps/web/src/app/features/employees/employees.component.ts
+++ b/apps/web/src/app/features/employees/employees.component.ts
@@ -1,15 +1,279 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
-import { employees } from "../../core/mock-data";
+import { ChangeDetectorRef, Component, NgZone, OnInit } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { Employee } from "../../core/models";
+import { EmployeePayload, EmployeesApiService } from "../../core/services/employees-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
+
+type EmployeeRole = EmployeePayload["role"];
+
+type EmployeeForm = {
+  id: number | null;
+  nome: string;
+  cpf: string;
+  telefone: string;
+  endereco: string;
+  matricula: string;
+  cargo: string;
+  dataAdmissao: string;
+  contatoEmergencia: string;
+  role: EmployeeRole;
+  email: string;
+  senha: string;
+};
 
 @Component({
   selector: "pf-employees",
   standalone: true,
-  imports: [CommonModule, StatusBadgeComponent],
+  imports: [CommonModule, FormsModule, StatusBadgeComponent],
   templateUrl: "./employees.component.html",
   styleUrl: "./employees.component.css"
 })
-export class EmployeesComponent {
-  readonly employees = employees;
+export class EmployeesComponent implements OnInit {
+  query = "";
+  employees: Employee[] = [];
+  isLoading = true;
+  errorMessage = "";
+  isModalOpen = false;
+  modalMode: "create" | "edit" = "create";
+  currentPage = 1;
+  pageSize = 10;
+  totalItems = 0;
+  totalPages = 1;
+  readonly roles: EmployeeRole[] = ["PROPRIETARIO", "ATENDENTE", "PADEIRO"];
+  form: EmployeeForm = this.getEmptyForm();
+
+  constructor(
+    private readonly employeesApiService: EmployeesApiService,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly ngZone: NgZone,
+  ) {}
+
+  ngOnInit(): void {
+    this.loadEmployees();
+  }
+
+  get filteredEmployees(): Employee[] {
+    return this.employees;
+  }
+
+  get totalEmployees(): number {
+    return this.totalItems;
+  }
+
+  get activeEmployees(): number {
+    return this.employees.filter((employee) => employee.status === "Ativo").length;
+  }
+
+  get attendanceRegistered(): number {
+    return this.employees.filter((employee) => (employee.registrosPonto?.length ?? 0) > 0).length;
+  }
+
+  get vacationRecords(): number {
+    return this.employees.reduce((total, employee) => total + (employee.ferias?.length ?? 0), 0);
+  }
+
+  retry(): void {
+    this.loadEmployees();
+  }
+
+  searchEmployees(): void {
+    this.currentPage = 1;
+    this.loadEmployees();
+  }
+
+  previousPage(): void {
+    if (this.currentPage <= 1) {
+      return;
+    }
+
+    this.currentPage -= 1;
+    this.loadEmployees();
+  }
+
+  nextPage(): void {
+    if (this.currentPage >= this.totalPages) {
+      return;
+    }
+
+    this.currentPage += 1;
+    this.loadEmployees();
+  }
+
+  openCreateModal(): void {
+    this.modalMode = "create";
+    this.form = this.getEmptyForm();
+    this.isModalOpen = true;
+  }
+
+  openEditModal(employee: Employee): void {
+    this.modalMode = "edit";
+    this.form = {
+      id: employee.id,
+      nome: employee.nome ?? employee.name,
+      cpf: employee.cpf ?? "",
+      telefone: employee.telefone ?? "",
+      endereco: employee.endereco ?? "",
+      matricula: employee.matricula ?? "",
+      cargo: employee.cargo ?? employee.role,
+      dataAdmissao: this.toDateInput(employee.dataAdmissao),
+      contatoEmergencia: employee.contatoEmergencia ?? "",
+      role: employee.accessRole ?? "ATENDENTE",
+      email: employee.email ?? "",
+      senha: "",
+    };
+    this.isModalOpen = true;
+  }
+
+  closeModal(): void {
+    this.isModalOpen = false;
+    this.form = this.getEmptyForm();
+  }
+
+  submitForm(): void {
+    if (!this.isFormValid()) {
+      this.showPersistenceError("Preencha todos os campos obrigatorios do funcionario.");
+      return;
+    }
+
+    const payload = this.toPayload();
+
+    if (this.modalMode === "edit" && this.form.id !== null) {
+      const updatePayload: Partial<EmployeePayload> = { ...payload };
+
+      if (!this.form.senha.trim()) {
+        delete updatePayload.senha;
+      }
+
+      this.employeesApiService.updateEmployee(this.form.id, updatePayload).subscribe({
+        next: () => {
+          this.closeModal();
+          this.loadEmployees();
+        },
+        error: () => this.showPersistenceError("Nao foi possivel atualizar o funcionario na API."),
+      });
+      return;
+    }
+
+    this.employeesApiService.createEmployee(payload).subscribe({
+      next: () => {
+        this.closeModal();
+        this.loadEmployees();
+      },
+      error: () => this.showPersistenceError("Nao foi possivel cadastrar o funcionario na API."),
+    });
+  }
+
+  deleteEmployee(employeeId: number): void {
+    this.employeesApiService.deleteEmployee(employeeId).subscribe({
+      next: () => this.loadEmployees(),
+      error: () => this.showPersistenceError("Nao foi possivel excluir o funcionario na API."),
+    });
+  }
+
+  formatRole(role?: string): string {
+    const labels: Record<string, string> = {
+      PROPRIETARIO: "Proprietario",
+      ATENDENTE: "Atendente",
+      PADEIRO: "Padeiro",
+    };
+
+    return labels[role ?? ""] ?? "Atendente";
+  }
+
+  private loadEmployees(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.changeDetectorRef.detectChanges();
+
+    this.employeesApiService.listEmployees({
+      busca: this.query,
+      page: this.currentPage,
+      limit: this.pageSize,
+    }).subscribe({
+      next: (response) => {
+        this.ngZone.run(() => {
+          this.employees = response.data.map((employee) => this.employeesApiService.normalizeEmployee(employee));
+          this.totalItems = response.pagination.total;
+          this.totalPages = response.pagination.totalPages;
+          this.currentPage = response.pagination.page;
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+      error: () => {
+        this.ngZone.run(() => {
+          this.employees = [];
+          this.totalItems = 0;
+          this.totalPages = 1;
+          this.errorMessage = "API de funcionarios indisponivel. Nao ha fallback mockado nesta tela.";
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+    });
+  }
+
+  private getEmptyForm(): EmployeeForm {
+    return {
+      id: null,
+      nome: "",
+      cpf: "",
+      telefone: "",
+      endereco: "",
+      matricula: "",
+      cargo: "",
+      dataAdmissao: new Date().toISOString().slice(0, 10),
+      contatoEmergencia: "",
+      role: "ATENDENTE",
+      email: "",
+      senha: "",
+    };
+  }
+
+  private toPayload(): EmployeePayload {
+    return {
+      nome: this.form.nome.trim(),
+      cpf: this.form.cpf.trim(),
+      telefone: this.form.telefone.trim(),
+      endereco: this.form.endereco.trim(),
+      matricula: this.form.matricula.trim(),
+      cargo: this.form.cargo.trim(),
+      dataAdmissao: this.form.dataAdmissao,
+      contatoEmergencia: this.form.contatoEmergencia.trim(),
+      role: this.form.role,
+      email: this.form.email.trim(),
+      senha: this.form.senha.trim(),
+      ativo: true,
+    };
+  }
+
+  private isFormValid(): boolean {
+    const requiredValues = [
+      this.form.nome,
+      this.form.cpf,
+      this.form.telefone,
+      this.form.endereco,
+      this.form.matricula,
+      this.form.cargo,
+      this.form.dataAdmissao,
+      this.form.contatoEmergencia,
+      this.form.role,
+      this.form.email,
+    ];
+
+    return requiredValues.every((value) => value.trim().length > 0) && (this.modalMode === "edit" || this.form.senha.trim().length > 0);
+  }
+
+  private toDateInput(date?: string): string {
+    if (!date) {
+      return new Date().toISOString().slice(0, 10);
+    }
+
+    return new Date(date).toISOString().slice(0, 10);
+  }
+
+  private showPersistenceError(message: string): void {
+    this.errorMessage = message;
+  }
 }

--- a/apps/web/src/app/features/history/history.component.css
+++ b/apps/web/src/app/features/history/history.component.css
@@ -18,6 +18,20 @@
   margin-top: 1rem;
 }
 
+.btn-cancel-sale {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.55rem 0.75rem;
+  background: #fff7ed;
+  color: #b45309;
+  font-weight: 700;
+}
+
+.btn-cancel-sale:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
 @media (max-width: 900px) {
   .table-panel {
     overflow-x: auto;

--- a/apps/web/src/app/features/history/history.component.css
+++ b/apps/web/src/app/features/history/history.component.css
@@ -1,4 +1,7 @@
 .historic-filters {
+  display: flex;
+  align-items: end;
+  gap: 1rem;
   margin-bottom: 1rem;
   flex-wrap: wrap;
 }
@@ -9,4 +12,18 @@
 
 .history-stats .stat-card {
   padding: 1rem 1.1rem;
+}
+
+.retry-button {
+  margin-top: 1rem;
+}
+
+@media (max-width: 900px) {
+  .table-panel {
+    overflow-x: auto;
+  }
+
+  .table-panel table {
+    min-width: 980px;
+  }
 }

--- a/apps/web/src/app/features/history/history.component.html
+++ b/apps/web/src/app/features/history/history.component.html
@@ -51,6 +51,7 @@
         <th>Pagamento</th>
         <th>Valor</th>
         <th>Status</th>
+        <th>Acoes</th>
       </tr>
     </thead>
     <tbody *ngIf="!isLoading && !errorMessage">
@@ -63,9 +64,14 @@
         <td>{{ sale.payment }}</td>
         <td>{{ formatCurrency(sale.value) }}</td>
         <td><pf-status-badge [text]="sale.status" /></td>
+        <td>
+          <button class="btn-cancel-sale" type="button" [disabled]="sale.status === 'CANCELADA'" (click)="cancelSale(sale.id)">
+            Cancelar
+          </button>
+        </td>
       </tr>
       <tr *ngIf="sales.length === 0">
-        <td colspan="8" class="empty-state">Nenhuma venda encontrada.</td>
+        <td colspan="9" class="empty-state">Nenhuma venda encontrada.</td>
       </tr>
     </tbody>
   </table>

--- a/apps/web/src/app/features/history/history.component.html
+++ b/apps/web/src/app/features/history/history.component.html
@@ -1,7 +1,7 @@
 <div class="page-header">
   <div>
     <div class="page-title">Historico de vendas</div>
-    <div class="page-subtitle">Consulta de transacoes, operadores e formas de pagamento.</div>
+    <div class="page-subtitle">Consulta de transacoes, operadores e formas de pagamento com dados da API.</div>
   </div>
   <a class="btn-primary" routerLink="/vendas/nova">Nova venda</a>
 </div>
@@ -9,47 +9,73 @@
 <div class="historic-filters">
   <div class="filter-group flex-1">
     <label class="form-label">Inicio do periodo</label>
-    <input class="form-input" type="date" />
+    <input class="form-input" type="date" [(ngModel)]="startDate" />
   </div>
   <div class="filter-group flex-1">
     <label class="form-label">Fim do periodo</label>
-    <input class="form-input" type="date" />
+    <input class="form-input" type="date" [(ngModel)]="endDate" />
   </div>
   <div class="filter-group flex-1">
     <label class="form-label">Funcionario</label>
-    <select class="form-select"><option>Todos os funcionarios</option></select>
+    <select class="form-select" [(ngModel)]="selectedEmployeeId">
+      <option value="">Todos os funcionarios</option>
+      <option *ngFor="let employee of employees" [value]="employee.id">{{ employee.nome || employee.name }}</option>
+    </select>
   </div>
-  <button class="btn-secondary" type="button">Filtrar resultados</button>
+  <button class="btn-secondary" type="button" (click)="applyFilters()">Filtrar resultados</button>
 </div>
 
 <div class="stats-grid history-stats">
-  <div class="stat-card"><div class="stat-label">Vendas totais</div><div class="stat-value">{{ formatCurrency(12450) }}</div></div>
-  <div class="stat-card"><div class="stat-label">Ticket medio</div><div class="stat-value">{{ formatCurrency(185.5) }}</div></div>
-  <div class="stat-card"><div class="stat-label">Vendas canceladas</div><div class="stat-value">03</div></div>
-  <div class="stat-card"><div class="stat-label">Operadores ativos</div><div class="stat-value">08</div></div>
+  <div class="stat-card"><div class="stat-label">Vendas totais</div><div class="stat-value">{{ formatCurrency(summary.totalSold) }}</div></div>
+  <div class="stat-card"><div class="stat-label">Ticket medio</div><div class="stat-value">{{ formatCurrency(summary.averageTicket) }}</div></div>
+  <div class="stat-card"><div class="stat-label">Vendas canceladas</div><div class="stat-value">{{ summary.canceledSales }}</div></div>
+  <div class="stat-card"><div class="stat-label">Operadores ativos</div><div class="stat-value">{{ summary.activeOperators }}</div></div>
 </div>
 
 <div class="table-panel">
+  <div *ngIf="isLoading" class="empty-state">Carregando historico da API...</div>
+
+  <div *ngIf="!isLoading && errorMessage" class="empty-state">
+    <div>{{ errorMessage }}</div>
+    <button class="btn-secondary retry-button" type="button" (click)="retry()">Tentar novamente</button>
+  </div>
+
   <table>
-    <thead>
+    <thead *ngIf="!isLoading && !errorMessage">
       <tr>
         <th>ID venda</th>
         <th>Data e hora</th>
         <th>Cliente</th>
+        <th>Funcionario</th>
+        <th>Itens</th>
         <th>Pagamento</th>
         <th>Valor</th>
         <th>Status</th>
       </tr>
     </thead>
-    <tbody>
+    <tbody *ngIf="!isLoading && !errorMessage">
       <tr *ngFor="let sale of sales">
-        <td>{{ sale.id }}</td>
+        <td>#{{ sale.id }}</td>
         <td>{{ sale.datetime }}</td>
         <td>{{ sale.client }}</td>
+        <td>{{ sale.funcionario?.nome || sale.funcionario?.name || "Nao informado" }}</td>
+        <td>{{ sale.mainProduct }}</td>
         <td>{{ sale.payment }}</td>
         <td>{{ formatCurrency(sale.value) }}</td>
         <td><pf-status-badge [text]="sale.status" /></td>
       </tr>
+      <tr *ngIf="sales.length === 0">
+        <td colspan="8" class="empty-state">Nenhuma venda encontrada.</td>
+      </tr>
     </tbody>
   </table>
+
+  <div *ngIf="!isLoading && !errorMessage" class="table-footer">
+    <span>Exibindo {{ sales.length }} de {{ totalItems }} vendas</span>
+    <div class="pagination">
+      <button class="page-btn" type="button" [disabled]="currentPage <= 1" (click)="previousPage()">Anterior</button>
+      <button class="page-btn active" type="button">{{ currentPage }} / {{ totalPages }}</button>
+      <button class="page-btn" type="button" [disabled]="currentPage >= totalPages" (click)="nextPage()">Proxima</button>
+    </div>
+  </div>
 </div>

--- a/apps/web/src/app/features/history/history.component.ts
+++ b/apps/web/src/app/features/history/history.component.ts
@@ -74,6 +74,15 @@ export class HistoryComponent implements OnInit {
     this.loadSales();
   }
 
+  cancelSale(saleId: string): void {
+    this.salesApiService.cancelSale(saleId).subscribe({
+      next: () => this.loadSales(),
+      error: () => {
+        this.errorMessage = "Nao foi possivel cancelar a venda na API.";
+      },
+    });
+  }
+
   private loadSales(): void {
     this.isLoading = true;
     this.errorMessage = "";

--- a/apps/web/src/app/features/history/history.component.ts
+++ b/apps/web/src/app/features/history/history.component.ts
@@ -1,20 +1,130 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { ChangeDetectorRef, Component, NgZone, OnInit } from "@angular/core";
+import { FormsModule } from "@angular/forms";
 import { RouterLink } from "@angular/router";
-import { StorageService } from "../../core/services/storage.service";
-import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
+import { Employee, Sale } from "../../core/models";
+import { EmployeesApiService } from "../../core/services/employees-api.service";
+import { SalesApiService } from "../../core/services/sales-api.service";
 import { formatCurrency } from "../../core/utils/format";
+import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 
 @Component({
   selector: "pf-history",
   standalone: true,
-  imports: [CommonModule, RouterLink, StatusBadgeComponent],
+  imports: [CommonModule, FormsModule, RouterLink, StatusBadgeComponent],
   templateUrl: "./history.component.html",
   styleUrl: "./history.component.css"
 })
-export class HistoryComponent {
-  readonly sales = this.storageService.getSales();
+export class HistoryComponent implements OnInit {
+  sales: Sale[] = [];
+  employees: Employee[] = [];
+  startDate = "";
+  endDate = "";
+  selectedEmployeeId = "";
+  currentPage = 1;
+  pageSize = 10;
+  totalItems = 0;
+  totalPages = 1;
+  isLoading = true;
+  errorMessage = "";
+  summary = {
+    totalSold: 0,
+    averageTicket: 0,
+    canceledSales: 0,
+    activeOperators: 0,
+  };
   readonly formatCurrency = formatCurrency;
 
-  constructor(private readonly storageService: StorageService) {}
+  constructor(
+    private readonly salesApiService: SalesApiService,
+    private readonly employeesApiService: EmployeesApiService,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly ngZone: NgZone,
+  ) {}
+
+  ngOnInit(): void {
+    this.loadEmployees();
+    this.loadSales();
+  }
+
+  applyFilters(): void {
+    this.currentPage = 1;
+    this.loadSales();
+  }
+
+  retry(): void {
+    this.loadSales();
+  }
+
+  previousPage(): void {
+    if (this.currentPage <= 1) {
+      return;
+    }
+
+    this.currentPage -= 1;
+    this.loadSales();
+  }
+
+  nextPage(): void {
+    if (this.currentPage >= this.totalPages) {
+      return;
+    }
+
+    this.currentPage += 1;
+    this.loadSales();
+  }
+
+  private loadSales(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.changeDetectorRef.detectChanges();
+
+    this.salesApiService.listSales({
+      inicio: this.startDate,
+      fim: this.endDate,
+      funcionarioId: this.selectedEmployeeId,
+      page: this.currentPage,
+      limit: this.pageSize,
+    }).subscribe({
+      next: (response) => {
+        this.ngZone.run(() => {
+          this.sales = response.data;
+          this.summary = response.summary;
+          this.totalItems = response.pagination.total;
+          this.totalPages = response.pagination.totalPages;
+          this.currentPage = response.pagination.page;
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+      error: () => {
+        this.ngZone.run(() => {
+          this.sales = [];
+          this.totalItems = 0;
+          this.totalPages = 1;
+          this.summary = {
+            totalSold: 0,
+            averageTicket: 0,
+            canceledSales: 0,
+            activeOperators: 0,
+          };
+          this.errorMessage = "API de vendas indisponivel. Nao ha fallback mockado nesta tela.";
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+    });
+  }
+
+  private loadEmployees(): void {
+    this.employeesApiService.listEmployees({ limit: 100 }).subscribe({
+      next: (response) => {
+        this.ngZone.run(() => {
+          this.employees = response.data;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+      error: () => undefined,
+    });
+  }
 }

--- a/apps/web/src/app/features/products/products.component.css
+++ b/apps/web/src/app/features/products/products.component.css
@@ -134,6 +134,13 @@
   height: 100%;
 }
 
+.product-image {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
 .visual-bread {
   background:
     radial-gradient(circle at 38% 68%, #c98b41 0 18%, transparent 19%),
@@ -356,6 +363,33 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
+}
+
+.product-form-full {
+  grid-column: 1 / -1;
+}
+
+.product-upload {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.product-upload ui5-file-uploader {
+  width: 100%;
+}
+
+.upload-helper {
+  color: #8290a6;
+  font-size: 0.78rem;
+  line-height: 1.45;
+}
+
+.product-upload-preview {
+  width: min(100%, 240px);
+  height: 132px;
+  border-radius: 12px;
+  border: 1px solid #e5ebf3;
+  object-fit: cover;
 }
 
 .product-modal-actions {

--- a/apps/web/src/app/features/products/products.component.css
+++ b/apps/web/src/app/features/products/products.component.css
@@ -236,25 +236,13 @@
   padding: 0;
 }
 
-.icon-action svg,
-.floating-stock-btn svg {
+.icon-action svg {
   width: 18px;
   height: 18px;
   stroke: currentColor;
   stroke-width: 1.9;
   stroke-linecap: round;
   stroke-linejoin: round;
-}
-
-.product-stock {
-  color: #9dadc2;
-  font-size: 0.72rem;
-  font-weight: 700;
-  white-space: nowrap;
-}
-
-.product-stock.low {
-  color: #d81919;
 }
 
 .products-summary {
@@ -265,6 +253,18 @@
   border-radius: 14px;
   background: #edf2f7;
   overflow: hidden;
+}
+
+.products-fallback-note {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.1rem;
+  border-radius: 12px;
+  background: #fff7ed;
+  border: 1px solid #fed7aa;
+  color: #9a3412;
 }
 
 .summary-item {
@@ -292,21 +292,6 @@
 
 .summary-value-green {
   color: #0e8a5b;
-}
-
-.floating-stock-btn {
-  position: absolute;
-  right: 0;
-  bottom: -2px;
-  width: 42px;
-  height: 42px;
-  display: grid;
-  place-items: center;
-  border: 0;
-  border-radius: 10px;
-  background: #0faa78;
-  color: #ffffff;
-  box-shadow: 0 10px 18px rgba(15, 170, 120, 0.2);
 }
 
 .product-modal-backdrop {

--- a/apps/web/src/app/features/products/products.component.html
+++ b/apps/web/src/app/features/products/products.component.html
@@ -1,8 +1,8 @@
 <div class="products-page">
   <div class="page-header products-header">
     <div>
-      <div class="page-title products-title">Gestão de Produtos</div>
-      <div class="page-subtitle">Gerencie seu catálogo, estoque e precificação em tempo real.</div>
+      <div class="page-title products-title">Gestao de Produtos</div>
+      <div class="page-subtitle">Gerencie seu catalogo e precificacao em tempo real.</div>
     </div>
 
     <button class="btn-new-product" type="button" (click)="openCreateModal()">
@@ -28,13 +28,19 @@
       <span class="sort-label">ORDENAR POR:</span>
       <select class="sort-select" [(ngModel)]="sortBy">
         <option value="recentes">Mais Recentes</option>
-        <option value="preco">Menor Preço</option>
-        <option value="estoque">Menor Estoque</option>
+        <option value="preco">Menor Preco</option>
       </select>
     </div>
   </div>
 
   <div class="products-grid">
+    <div *ngIf="isLoading" class="empty-state">Carregando produtos da API...</div>
+
+    <div *ngIf="!isLoading && errorMessage" class="empty-state">
+      <div>{{ errorMessage }}</div>
+      <button class="btn-secondary" type="button" (click)="retry()">Tentar novamente</button>
+    </div>
+
     <article *ngFor="let product of filteredProducts" class="product-card">
       <div class="product-hero" [ngClass]="getProductVisual(product.name)">
         <span class="product-category-badge">{{ product.category }}</span>
@@ -62,46 +68,43 @@
               </svg>
             </button>
           </div>
-
-          <div class="product-stock" [class.low]="product.stock < 10">Estoque: {{ product.stock }} {{ product.unit }}</div>
         </div>
       </div>
     </article>
   </div>
 
+  <div *ngIf="!isLoading && isUsingFallbackData" class="products-fallback-note">
+    <span>{{ fallbackMessage }}</span>
+    <button class="btn-secondary" type="button" (click)="retry()">Tentar API novamente</button>
+  </div>
+
   <div class="products-summary">
-    <div class="summary-item">
-      <div class="summary-label">TOTAL EM ESTOQUE</div>
-      <div class="summary-value">{{ formatCurrency(totalInventoryValue) }}</div>
-    </div>
     <div class="summary-item">
       <div class="summary-label">PRODUTOS ATIVOS</div>
       <div class="summary-value">{{ activeProductsCount }}</div>
     </div>
     <div class="summary-item">
-      <div class="summary-label">ITENS S/ MOVIMENTAÇÃO</div>
-      <div class="summary-value">{{ staleProductsCount }}</div>
+      <div class="summary-label">CATEGORIAS</div>
+      <div class="summary-value">{{ categoriesCount }}</div>
     </div>
     <div class="summary-item">
-      <div class="summary-label">GIRO DE ESTOQUE</div>
-      <div class="summary-value summary-value-green">{{ inventoryTurnover }}%</div>
+      <div class="summary-label">COM CATEGORIA</div>
+      <div class="summary-value">{{ categorizedProductsCount }}</div>
+    </div>
+    <div class="summary-item">
+      <div class="summary-label">PRECO MEDIO</div>
+      <div class="summary-value summary-value-green">{{ formatCurrency(averagePrice) }}</div>
     </div>
   </div>
-
-  <button class="floating-stock-btn" type="button" aria-label="Atalho de estoque">
-    <svg viewBox="0 0 24 24" fill="none">
-      <path d="M4 7h16M6 7v10M18 7v10M8 11h8M8 15h8M4 19h16" />
-    </svg>
-  </button>
 
   <div *ngIf="isModalOpen" class="product-modal-backdrop" (click)="closeModal()">
     <div class="product-modal" (click)="$event.stopPropagation()">
       <div class="product-modal-head">
         <div>
           <div class="product-modal-title">{{ modalMode === 'edit' ? 'Editar Produto' : 'Novo Produto' }}</div>
-          <div class="product-modal-subtitle">Os dados serão salvos localmente neste navegador.</div>
+          <div class="product-modal-subtitle">Os dados serao salvos localmente neste navegador.</div>
         </div>
-        <button class="modal-close" type="button" (click)="closeModal()">×</button>
+        <button class="modal-close" type="button" (click)="closeModal()">x</button>
       </div>
 
       <form class="product-form" (ngSubmit)="submitForm()">
@@ -124,24 +127,14 @@
           </div>
 
           <div class="form-group">
-            <label class="form-label">Unidade</label>
-            <input class="form-input" name="unit" [(ngModel)]="form.unit" required />
-          </div>
-
-          <div class="form-group">
-            <label class="form-label">Estoque</label>
-            <input class="form-input" name="stock" type="number" min="0" [(ngModel)]="form.stock" required />
-          </div>
-
-          <div class="form-group">
-            <label class="form-label">Preço</label>
+            <label class="form-label">Preco</label>
             <input class="form-input" name="price" type="number" min="0" step="0.01" [(ngModel)]="form.price" required />
           </div>
         </div>
 
         <div class="product-modal-actions">
           <button class="btn-secondary" type="button" (click)="closeModal()">Cancelar</button>
-          <button class="btn-primary" type="submit">{{ modalMode === 'edit' ? 'Salvar alterações' : 'Cadastrar produto' }}</button>
+          <button class="btn-primary" type="submit">{{ modalMode === 'edit' ? 'Salvar alteracoes' : 'Cadastrar produto' }}</button>
         </div>
       </form>
     </div>

--- a/apps/web/src/app/features/products/products.component.html
+++ b/apps/web/src/app/features/products/products.component.html
@@ -74,11 +74,6 @@
     </article>
   </div>
 
-  <div *ngIf="!isLoading && isUsingFallbackData" class="products-fallback-note">
-    <span>{{ fallbackMessage }}</span>
-    <button class="btn-secondary" type="button" (click)="retry()">Tentar API novamente</button>
-  </div>
-
   <div class="products-summary">
     <div class="summary-item">
       <div class="summary-label">PRODUTOS ATIVOS</div>

--- a/apps/web/src/app/features/products/products.component.html
+++ b/apps/web/src/app/features/products/products.component.html
@@ -42,18 +42,19 @@
     </div>
 
     <article *ngFor="let product of filteredProducts" class="product-card">
-      <div class="product-hero" [ngClass]="getProductVisual(product.name)">
-        <span class="product-category-badge">{{ product.category }}</span>
-        <div class="product-scene" [ngClass]="getProductVisual(product.name)"></div>
+      <div class="product-hero" [ngClass]="!product.imagemUrl ? getProductVisual(product.nome) : null">
+        <span class="product-category-badge">{{ product.categoria }}</span>
+        <img *ngIf="product.imagemUrl" class="product-image" [src]="product.imagemUrl" [alt]="product.nome" />
+        <div *ngIf="!product.imagemUrl" class="product-scene" [ngClass]="getProductVisual(product.nome)"></div>
       </div>
 
       <div class="product-info">
         <div class="product-head">
-          <div class="product-name">{{ product.name }}</div>
-          <div class="product-price">{{ formatCurrency(product.price) }}</div>
+          <div class="product-name">{{ product.nome }}</div>
+          <div class="product-price">{{ formatCurrency(product.precoBase || 0) }}</div>
         </div>
 
-        <div class="product-sku">SKU: {{ product.sku }}</div>
+        <div class="product-sku">Codigo de barras: {{ product.codigoBarras }}</div>
 
         <div class="product-footer">
           <div class="product-actions">
@@ -102,7 +103,7 @@
       <div class="product-modal-head">
         <div>
           <div class="product-modal-title">{{ modalMode === 'edit' ? 'Editar Produto' : 'Novo Produto' }}</div>
-          <div class="product-modal-subtitle">Os dados serao salvos localmente neste navegador.</div>
+          <div class="product-modal-subtitle">Campos alinhados ao contrato do backend: nome, categoria, codigo de barras, preco base e imagem.</div>
         </div>
         <button class="modal-close" type="button" (click)="closeModal()">x</button>
       </div>
@@ -111,24 +112,43 @@
         <div class="product-form-grid">
           <div class="form-group">
             <label class="form-label">Nome</label>
-            <input class="form-input" name="name" [(ngModel)]="form.name" required />
+            <input class="form-input" name="nome" [(ngModel)]="form.nome" required />
           </div>
 
           <div class="form-group">
             <label class="form-label">Categoria</label>
-            <select class="form-select" name="category" [(ngModel)]="form.category">
+            <select class="form-select" name="categoria" [(ngModel)]="form.categoria">
               <option *ngFor="let item of productCategories" [value]="item">{{ item }}</option>
             </select>
           </div>
 
           <div class="form-group">
-            <label class="form-label">SKU</label>
-            <input class="form-input" name="sku" [(ngModel)]="form.sku" required />
+            <label class="form-label">Codigo de barras</label>
+            <input class="form-input" name="codigoBarras" [(ngModel)]="form.codigoBarras" required />
           </div>
 
           <div class="form-group">
-            <label class="form-label">Preco</label>
-            <input class="form-input" name="price" type="number" min="0" step="0.01" [(ngModel)]="form.price" required />
+            <label class="form-label">Preco base</label>
+            <input class="form-input" name="precoBase" type="number" min="0" step="0.01" [(ngModel)]="form.precoBase" required />
+          </div>
+
+          <div class="form-group product-form-full">
+            <label class="form-label">Imagem do produto (URL)</label>
+            <input class="form-input" name="imagemUrl" type="url" [(ngModel)]="form.imagemUrl" />
+          </div>
+
+          <div class="form-group product-form-full">
+            <label class="form-label">Upload de imagem</label>
+            <div class="product-upload">
+              <ui5-file-uploader
+                accept="image/*"
+                placeholder="Selecione uma imagem do produto"
+                [maxFileSize]="1"
+                (ui5Change)="onImageSelect($event)"
+              ></ui5-file-uploader>
+              <span class="upload-helper">Fundamental NGX UI5 FileUploader ativo. Nesta etapa, a imagem vira preview local; o upload real entra quando ligarmos o storage.</span>
+            </div>
+            <img *ngIf="form.imagemUrl" class="product-upload-preview" [src]="form.imagemUrl" alt="Preview do produto" />
           </div>
         </div>
 

--- a/apps/web/src/app/features/products/products.component.ts
+++ b/apps/web/src/app/features/products/products.component.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { Product } from "../../core/models";
+import { products as mockProducts } from "../../core/mock-data";
+import { ProductsApiService } from "../../core/services/products-api.service";
 import { StorageService } from "../../core/services/storage.service";
 import { formatCurrency } from "../../core/utils/format";
 
@@ -10,8 +12,6 @@ type ProductForm = {
   name: string;
   category: string;
   sku: string;
-  stock: number;
-  unit: string;
   price: number;
 };
 
@@ -22,19 +22,28 @@ type ProductForm = {
   templateUrl: "./products.component.html",
   styleUrl: "./products.component.css"
 })
-export class ProductsComponent {
+export class ProductsComponent implements OnInit {
   category = "Todos";
   sortBy = "recentes";
   isModalOpen = false;
   modalMode: "create" | "edit" = "create";
   products: Product[] = [];
+  isLoading = true;
+  errorMessage = "";
+  isUsingFallbackData = false;
+  fallbackMessage = "";
   readonly categories = ["Todos", "Paes", "Frios", "Bebidas", "Mercearia"];
   readonly productCategories = ["Paes", "Frios", "Bebidas", "Mercearia"];
   readonly formatCurrency = formatCurrency;
 
   form: ProductForm = this.getEmptyForm();
 
-  constructor(private readonly storageService: StorageService) {
+  constructor(
+    private readonly storageService: StorageService,
+    private readonly productsApiService: ProductsApiService,
+  ) {}
+
+  ngOnInit(): void {
     this.loadProducts();
   }
 
@@ -45,32 +54,33 @@ export class ProductsComponent {
       return [...filtered].sort((a, b) => a.price - b.price);
     }
 
-    if (this.sortBy === "estoque") {
-      return [...filtered].sort((a, b) => a.stock - b.stock);
-    }
-
     return [...filtered].sort((a, b) => b.id - a.id);
   }
 
-  get totalInventoryValue(): number {
-    return this.products.reduce((sum, product) => sum + product.price * product.stock, 0);
+  get averagePrice(): number {
+    if (!this.products.length) {
+      return 0;
+    }
+
+    const total = this.products.reduce((sum, product) => sum + product.price, 0);
+
+    return Number((total / this.products.length).toFixed(2));
   }
 
   get activeProductsCount(): number {
     return this.products.length;
   }
 
-  get staleProductsCount(): number {
-    return this.products.filter((product) => product.stock <= 12).length;
+  get categorizedProductsCount(): number {
+    return this.products.filter((product) => product.category.trim().length > 0).length;
   }
 
-  get inventoryTurnover(): number {
+  get categoriesCount(): number {
     if (!this.products.length) {
       return 0;
     }
 
-    const inStock = this.products.filter((product) => product.stock > 0).length;
-    return Math.round((inStock / this.products.length) * 100);
+    return new Set(this.products.map((product) => product.category)).size;
   }
 
   openCreateModal(): void {
@@ -96,12 +106,12 @@ export class ProductsComponent {
       name: this.form.name.trim(),
       category: this.form.category,
       sku: this.form.sku.trim(),
-      stock: Number(this.form.stock),
-      unit: this.form.unit.trim(),
+      stock: 0,
+      unit: "un",
       price: Number(this.form.price)
     };
 
-    if (!normalizedProduct.name || !normalizedProduct.sku || !normalizedProduct.unit) {
+    if (!normalizedProduct.name || !normalizedProduct.sku) {
       return;
     }
 
@@ -120,6 +130,10 @@ export class ProductsComponent {
     this.storageService.saveProducts(this.products);
   }
 
+  retry(): void {
+    this.loadProducts();
+  }
+
   getProductVisual(productName: string): string {
     if (productName.includes("Pao")) return "visual-bread";
     if (productName.includes("Presunto")) return "visual-coldcuts";
@@ -131,7 +145,29 @@ export class ProductsComponent {
   }
 
   private loadProducts(): void {
-    this.products = this.storageService.getProducts();
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.isUsingFallbackData = false;
+    this.fallbackMessage = "";
+
+    this.productsApiService.listProducts().subscribe({
+      next: (products) => {
+        this.products = products;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.products = this.storageService.getProducts();
+
+        if (!this.products.length) {
+          this.products = mockProducts;
+        }
+
+        this.isUsingFallbackData = true;
+        this.fallbackMessage =
+          "API de produtos indisponivel no momento. Exibindo dados locais para continuarmos a validacao da tela.";
+        this.isLoading = false;
+      },
+    });
   }
 
   private getEmptyForm(): ProductForm {
@@ -140,8 +176,6 @@ export class ProductsComponent {
       name: "",
       category: "Paes",
       sku: "",
-      stock: 0,
-      unit: "un",
       price: 0
     };
   }

--- a/apps/web/src/app/features/products/products.component.ts
+++ b/apps/web/src/app/features/products/products.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { Component, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
+import { FileUploader } from "@fundamental-ngx/ui5-webcomponents/file-uploader";
 import { Product } from "../../core/models";
 import { products as mockProducts } from "../../core/mock-data";
 import { ProductsApiService } from "../../core/services/products-api.service";
@@ -9,16 +10,17 @@ import { formatCurrency } from "../../core/utils/format";
 
 type ProductForm = {
   id: number | null;
-  name: string;
-  category: string;
-  sku: string;
-  price: number;
+  nome: string;
+  categoria: string;
+  codigoBarras: string;
+  precoBase: number;
+  imagemUrl: string;
 };
 
 @Component({
   selector: "pf-products",
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, FileUploader],
   templateUrl: "./products.component.html",
   styleUrl: "./products.component.css"
 })
@@ -32,8 +34,8 @@ export class ProductsComponent implements OnInit {
   errorMessage = "";
   isUsingFallbackData = false;
   fallbackMessage = "";
-  readonly categories = ["Todos", "Paes", "Frios", "Bebidas", "Mercearia"];
-  readonly productCategories = ["Paes", "Frios", "Bebidas", "Mercearia"];
+  categories = ["Todos", "Paes", "Frios", "Bebidas", "Mercearia"];
+  productCategories = ["Paes", "Frios", "Bebidas", "Mercearia"];
   readonly formatCurrency = formatCurrency;
 
   form: ProductForm = this.getEmptyForm();
@@ -44,14 +46,15 @@ export class ProductsComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.loadCategories();
     this.loadProducts();
   }
 
   get filteredProducts() {
-    const filtered = this.products.filter((product) => this.category === "Todos" || product.category === this.category);
+    const filtered = this.products.filter((product) => this.category === "Todos" || product.categoria === this.category);
 
     if (this.sortBy === "preco") {
-      return [...filtered].sort((a, b) => a.price - b.price);
+      return [...filtered].sort((a, b) => Number(a.precoBase) - Number(b.precoBase));
     }
 
     return [...filtered].sort((a, b) => b.id - a.id);
@@ -62,7 +65,7 @@ export class ProductsComponent implements OnInit {
       return 0;
     }
 
-    const total = this.products.reduce((sum, product) => sum + product.price, 0);
+    const total = this.products.reduce((sum, product) => sum + Number(product.precoBase), 0);
 
     return Number((total / this.products.length).toFixed(2));
   }
@@ -72,7 +75,7 @@ export class ProductsComponent implements OnInit {
   }
 
   get categorizedProductsCount(): number {
-    return this.products.filter((product) => product.category.trim().length > 0).length;
+    return this.products.filter((product) => product.categoria?.trim().length).length;
   }
 
   get categoriesCount(): number {
@@ -80,7 +83,7 @@ export class ProductsComponent implements OnInit {
       return 0;
     }
 
-    return new Set(this.products.map((product) => product.category)).size;
+    return new Set(this.products.map((product) => product.categoria)).size;
   }
 
   openCreateModal(): void {
@@ -91,7 +94,14 @@ export class ProductsComponent implements OnInit {
 
   openEditModal(product: Product): void {
     this.modalMode = "edit";
-    this.form = { ...product };
+    this.form = {
+      id: product.id,
+      nome: product.nome ?? product.name,
+      categoria: product.categoria ?? product.category,
+      codigoBarras: product.codigoBarras ?? product.sku,
+      precoBase: product.precoBase ?? product.price,
+      imagemUrl: product.imagemUrl ?? "",
+    };
     this.isModalOpen = true;
   }
 
@@ -103,38 +113,72 @@ export class ProductsComponent implements OnInit {
   submitForm(): void {
     const normalizedProduct: Product = {
       id: this.form.id ?? this.generateNextId(),
-      name: this.form.name.trim(),
-      category: this.form.category,
-      sku: this.form.sku.trim(),
+      nome: this.form.nome.trim(),
+      categoria: this.form.categoria,
+      codigoBarras: this.form.codigoBarras.trim(),
+      precoBase: Number(this.form.precoBase),
+      imagemUrl: this.form.imagemUrl.trim() || null,
+      name: this.form.nome.trim(),
+      category: this.form.categoria,
+      sku: this.form.codigoBarras.trim(),
       stock: 0,
       unit: "un",
-      price: Number(this.form.price)
+      price: Number(this.form.precoBase)
     };
 
-    if (!normalizedProduct.name || !normalizedProduct.sku) {
+    if (!normalizedProduct.nome || !normalizedProduct.codigoBarras) {
       return;
     }
 
     if (this.modalMode === "edit" && this.form.id !== null) {
-      this.products = this.products.map((product) => (product.id === this.form.id ? normalizedProduct : product));
+      this.productsApiService.updateProduct(normalizedProduct).subscribe({
+        next: (updatedProduct) => {
+          this.products = this.products.map((product) => (product.id === this.form.id ? updatedProduct : product));
+          this.storageService.saveProducts(this.products);
+          this.closeModal();
+        },
+        error: () => this.saveProductLocally(normalizedProduct),
+      });
     } else {
-      this.products = [normalizedProduct, ...this.products];
+      this.productsApiService.createProduct(normalizedProduct).subscribe({
+        next: (createdProduct) => {
+          this.products = [createdProduct, ...this.products];
+          this.storageService.saveProducts(this.products);
+          this.closeModal();
+        },
+        error: () => this.saveProductLocally(normalizedProduct),
+      });
     }
-
-    this.storageService.saveProducts(this.products);
-    this.closeModal();
   }
 
   deleteProduct(productId: number): void {
-    this.products = this.products.filter((product) => product.id !== productId);
-    this.storageService.saveProducts(this.products);
+    this.productsApiService.deleteProduct(productId).subscribe({
+      next: () => this.removeProductLocally(productId),
+      error: () => this.removeProductLocally(productId),
+    });
+  }
+
+  onImageSelect(event: Event): void {
+    const uploader = event.target as EventTarget & { files?: FileList | null };
+    const file = uploader.files?.item(0);
+
+    if (!file) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.form.imagemUrl = String(reader.result ?? "");
+    };
+    reader.readAsDataURL(file);
   }
 
   retry(): void {
     this.loadProducts();
   }
 
-  getProductVisual(productName: string): string {
+  getProductVisual(productName: string | undefined): string {
+    if (!productName) return "visual-default";
     if (productName.includes("Pao")) return "visual-bread";
     if (productName.includes("Presunto")) return "visual-coldcuts";
     if (productName.includes("Cafe")) return "visual-coffee";
@@ -152,14 +196,16 @@ export class ProductsComponent implements OnInit {
 
     this.productsApiService.listProducts().subscribe({
       next: (products) => {
-        this.products = products;
+        this.products = products.map((product) => this.productsApiService.normalizeProduct(product));
         this.isLoading = false;
       },
       error: () => {
-        this.products = this.storageService.getProducts();
+        this.products = this.storageService
+          .getProducts()
+          .map((product) => this.productsApiService.normalizeProduct(product));
 
         if (!this.products.length) {
-          this.products = mockProducts;
+          this.products = mockProducts.map((product) => this.productsApiService.normalizeProduct(product));
         }
 
         this.isUsingFallbackData = true;
@@ -173,14 +219,49 @@ export class ProductsComponent implements OnInit {
   private getEmptyForm(): ProductForm {
     return {
       id: null,
-      name: "",
-      category: "Paes",
-      sku: "",
-      price: 0
+      nome: "",
+      categoria: "Paes",
+      codigoBarras: "",
+      precoBase: 0,
+      imagemUrl: "",
     };
   }
 
   private generateNextId(): number {
     return this.products.reduce((max, product) => Math.max(max, product.id), 100) + 1;
+  }
+
+  private loadCategories(): void {
+    this.productsApiService.listCategories().subscribe({
+      next: (categories) => {
+        const validCategories = categories.filter((item) => item.trim().length > 0);
+        this.productCategories = validCategories.length ? validCategories : this.productCategories;
+        this.categories = ["Todos", ...this.productCategories];
+      },
+      error: () => undefined,
+    });
+  }
+
+  private saveProductLocally(product: Product): void {
+    const normalizedProduct = this.productsApiService.normalizeProduct(product);
+
+    if (this.modalMode === "edit" && this.form.id !== null) {
+      this.products = this.products.map((currentProduct) =>
+        currentProduct.id === this.form.id ? normalizedProduct : currentProduct,
+      );
+    } else {
+      this.products = [normalizedProduct, ...this.products];
+    }
+
+    this.storageService.saveProducts(this.products);
+    this.isUsingFallbackData = true;
+    this.fallbackMessage =
+      "API de produtos indisponivel. Alteracao aplicada localmente para manter a validacao da tela.";
+    this.closeModal();
+  }
+
+  private removeProductLocally(productId: number): void {
+    this.products = this.products.filter((product) => product.id !== productId);
+    this.storageService.saveProducts(this.products);
   }
 }

--- a/apps/web/src/app/features/products/products.component.ts
+++ b/apps/web/src/app/features/products/products.component.ts
@@ -1,11 +1,9 @@
 import { CommonModule } from "@angular/common";
-import { Component, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, NgZone, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { FileUploader } from "@fundamental-ngx/ui5-webcomponents/file-uploader";
 import { Product } from "../../core/models";
-import { products as mockProducts } from "../../core/mock-data";
 import { ProductsApiService } from "../../core/services/products-api.service";
-import { StorageService } from "../../core/services/storage.service";
 import { formatCurrency } from "../../core/utils/format";
 
 type ProductForm = {
@@ -32,8 +30,6 @@ export class ProductsComponent implements OnInit {
   products: Product[] = [];
   isLoading = true;
   errorMessage = "";
-  isUsingFallbackData = false;
-  fallbackMessage = "";
   categories = ["Todos", "Paes", "Frios", "Bebidas", "Mercearia"];
   productCategories = ["Paes", "Frios", "Bebidas", "Mercearia"];
   readonly formatCurrency = formatCurrency;
@@ -41,8 +37,9 @@ export class ProductsComponent implements OnInit {
   form: ProductForm = this.getEmptyForm();
 
   constructor(
-    private readonly storageService: StorageService,
     private readonly productsApiService: ProductsApiService,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly ngZone: NgZone,
   ) {}
 
   ngOnInit(): void {
@@ -134,19 +131,17 @@ export class ProductsComponent implements OnInit {
       this.productsApiService.updateProduct(normalizedProduct).subscribe({
         next: (updatedProduct) => {
           this.products = this.products.map((product) => (product.id === this.form.id ? updatedProduct : product));
-          this.storageService.saveProducts(this.products);
           this.closeModal();
         },
-        error: () => this.saveProductLocally(normalizedProduct),
+        error: () => this.showPersistenceError("Nao foi possivel atualizar o produto na API."),
       });
     } else {
       this.productsApiService.createProduct(normalizedProduct).subscribe({
         next: (createdProduct) => {
           this.products = [createdProduct, ...this.products];
-          this.storageService.saveProducts(this.products);
           this.closeModal();
         },
-        error: () => this.saveProductLocally(normalizedProduct),
+        error: () => this.showPersistenceError("Nao foi possivel cadastrar o produto na API."),
       });
     }
   }
@@ -154,7 +149,7 @@ export class ProductsComponent implements OnInit {
   deleteProduct(productId: number): void {
     this.productsApiService.deleteProduct(productId).subscribe({
       next: () => this.removeProductLocally(productId),
-      error: () => this.removeProductLocally(productId),
+      error: () => this.showPersistenceError("Nao foi possivel excluir o produto na API."),
     });
   }
 
@@ -191,27 +186,23 @@ export class ProductsComponent implements OnInit {
   private loadProducts(): void {
     this.isLoading = true;
     this.errorMessage = "";
-    this.isUsingFallbackData = false;
-    this.fallbackMessage = "";
+    this.changeDetectorRef.detectChanges();
 
     this.productsApiService.listProducts().subscribe({
       next: (products) => {
-        this.products = products.map((product) => this.productsApiService.normalizeProduct(product));
-        this.isLoading = false;
+        this.ngZone.run(() => {
+          this.products = products.map((product) => this.productsApiService.normalizeProduct(product));
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
       },
       error: () => {
-        this.products = this.storageService
-          .getProducts()
-          .map((product) => this.productsApiService.normalizeProduct(product));
-
-        if (!this.products.length) {
-          this.products = mockProducts.map((product) => this.productsApiService.normalizeProduct(product));
-        }
-
-        this.isUsingFallbackData = true;
-        this.fallbackMessage =
-          "API de produtos indisponivel no momento. Exibindo dados locais para continuarmos a validacao da tela.";
-        this.isLoading = false;
+        this.ngZone.run(() => {
+          this.products = [];
+          this.errorMessage = "API de produtos indisponivel. Nao ha fallback mockado nesta tela.";
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
       },
     });
   }
@@ -234,34 +225,22 @@ export class ProductsComponent implements OnInit {
   private loadCategories(): void {
     this.productsApiService.listCategories().subscribe({
       next: (categories) => {
-        const validCategories = categories.filter((item) => item.trim().length > 0);
-        this.productCategories = validCategories.length ? validCategories : this.productCategories;
-        this.categories = ["Todos", ...this.productCategories];
+        this.ngZone.run(() => {
+          const validCategories = categories.filter((item) => item.trim().length > 0);
+          this.productCategories = validCategories.length ? validCategories : this.productCategories;
+          this.categories = ["Todos", ...this.productCategories];
+          this.changeDetectorRef.detectChanges();
+        });
       },
       error: () => undefined,
     });
   }
 
-  private saveProductLocally(product: Product): void {
-    const normalizedProduct = this.productsApiService.normalizeProduct(product);
-
-    if (this.modalMode === "edit" && this.form.id !== null) {
-      this.products = this.products.map((currentProduct) =>
-        currentProduct.id === this.form.id ? normalizedProduct : currentProduct,
-      );
-    } else {
-      this.products = [normalizedProduct, ...this.products];
-    }
-
-    this.storageService.saveProducts(this.products);
-    this.isUsingFallbackData = true;
-    this.fallbackMessage =
-      "API de produtos indisponivel. Alteracao aplicada localmente para manter a validacao da tela.";
-    this.closeModal();
-  }
-
   private removeProductLocally(productId: number): void {
     this.products = this.products.filter((product) => product.id !== productId);
-    this.storageService.saveProducts(this.products);
+  }
+
+  private showPersistenceError(message: string): void {
+    this.errorMessage = message;
   }
 }

--- a/apps/web/src/app/features/reports/reports.component.css
+++ b/apps/web/src/app/features/reports/reports.component.css
@@ -1,3 +1,11 @@
+.report-toolbar {
+  flex-wrap: wrap;
+}
+
+.report-toolbar .form-input {
+  width: 150px;
+}
+
 .bar-chart {
   display: flex;
   align-items: end;
@@ -45,4 +53,20 @@
 
 .top-product-sales {
   color: var(--text-muted);
+}
+
+.top-product-revenue,
+.bar-value {
+  color: var(--text-muted);
+  font-size: 0.78rem;
+}
+
+.retry-button {
+  margin-top: 1rem;
+}
+
+@media (max-width: 720px) {
+  .report-toolbar .form-input {
+    width: 100%;
+  }
 }

--- a/apps/web/src/app/features/reports/reports.component.html
+++ b/apps/web/src/app/features/reports/reports.component.html
@@ -1,40 +1,58 @@
 <div class="page-header">
   <div>
     <div class="page-title">Relatorios</div>
-    <div class="page-subtitle">KPIs consolidados, top produtos e visao do desempenho acumulado.</div>
+    <div class="page-subtitle">KPIs consolidados, top produtos e vendas por periodo vindos da API.</div>
   </div>
-  <div class="toolbar">
-    <select class="report-filter"><option>Ultimos 30 dias</option></select>
-    <button class="btn-primary" type="button">Gerar ranking completo</button>
+  <div class="toolbar report-toolbar">
+    <input class="form-input" type="date" [(ngModel)]="dataInicio" aria-label="Data inicial" />
+    <input class="form-input" type="date" [(ngModel)]="dataFim" aria-label="Data final" />
+    <button class="btn-primary" type="button" (click)="applyFilters()">Gerar relatorio</button>
   </div>
 </div>
 
-<div class="stats-grid">
-  <div class="stat-card"><div class="stat-label">Total vendido</div><div class="stat-value">{{ formatCurrency(reports.totalSold) }}</div></div>
-  <div class="stat-card"><div class="stat-label">Numero de vendas</div><div class="stat-value">{{ reports.totalOrders }}</div></div>
-  <div class="stat-card"><div class="stat-label">Ticket medio</div><div class="stat-value">{{ formatCurrency(reports.averageTicket) }}</div></div>
-  <div class="stat-card"><div class="stat-label">Crescimento</div><div class="stat-value">+12%</div></div>
+<div *ngIf="isLoading" class="panel empty-state">Carregando relatorio da API...</div>
+
+<div *ngIf="!isLoading && errorMessage" class="panel empty-state">
+  <div>{{ errorMessage }}</div>
+  <button class="btn-secondary retry-button" type="button" (click)="retry()">Tentar novamente</button>
 </div>
 
-<div class="row col-2">
-  <div class="panel">
-    <div class="panel-title">Volume de vendas diario</div>
-    <div class="panel-sub">Desempenho acumulado no periodo selecionado</div>
-    <div class="bar-chart">
-      <div *ngFor="let item of weeklySales; let index = index" class="bar-wrap">
-        <div class="bar" [class.active]="index >= 4" [style.height.px]="item.value / 14 < 20 ? 20 : item.value / 14"></div>
-        <div class="bar-label">{{ item.day }}</div>
+<ng-container *ngIf="!isLoading && !errorMessage">
+  <div class="stats-grid">
+    <div class="stat-card"><div class="stat-label">Total vendido</div><div class="stat-value">{{ formatCurrency(report.totalSold) }}</div></div>
+    <div class="stat-card"><div class="stat-label">Numero de vendas</div><div class="stat-value">{{ report.totalOrders }}</div></div>
+    <div class="stat-card"><div class="stat-label">Ticket medio</div><div class="stat-value">{{ formatCurrency(report.averageTicket) }}</div></div>
+    <div class="stat-card"><div class="stat-label">Crescimento</div><div class="stat-value">{{ growthLabel }}</div></div>
+  </div>
+
+  <div class="row col-2">
+    <div class="panel">
+      <div class="panel-title">Volume de vendas diario</div>
+      <div class="panel-sub">Desempenho acumulado no periodo selecionado</div>
+      <div class="bar-chart" *ngIf="report.dailySales.length; else noDailySales">
+        <div *ngFor="let item of report.dailySales; let index = index" class="bar-wrap">
+          <div class="bar" [class.active]="index >= report.dailySales.length / 2" [style.height.px]="getBarHeight(item.value)"></div>
+          <div class="bar-label">{{ item.day }}</div>
+          <div class="bar-value">{{ item.orders }}</div>
+        </div>
       </div>
+      <ng-template #noDailySales>
+        <div class="empty-state">Nenhuma venda no periodo.</div>
+      </ng-template>
     </div>
-  </div>
 
-  <div class="panel">
-    <div class="panel-title">Top produtos</div>
-    <div class="panel-sub">Itens com melhor saida no periodo</div>
-    <div *ngFor="let product of reports.topProducts; let index = index" class="top-product-item">
-      <div class="top-rank">{{ index + 1 }}</div>
-      <div class="top-product-name">{{ product.name }}</div>
-      <div class="top-product-sales">{{ product.sales }} vendas</div>
+    <div class="panel">
+      <div class="panel-title">Top produtos</div>
+      <div class="panel-sub">Itens com melhor saida no periodo</div>
+      <div *ngFor="let product of report.topProducts; let index = index" class="top-product-item">
+        <div class="top-rank">{{ index + 1 }}</div>
+        <div>
+          <div class="top-product-name">{{ product.name }}</div>
+          <div class="top-product-revenue">{{ formatCurrency(product.revenue) }}</div>
+        </div>
+        <div class="top-product-sales">{{ product.sales }} un.</div>
+      </div>
+      <div *ngIf="report.topProducts.length === 0" class="empty-state">Sem produtos vendidos no periodo.</div>
     </div>
   </div>
-</div>
+</ng-container>

--- a/apps/web/src/app/features/reports/reports.component.ts
+++ b/apps/web/src/app/features/reports/reports.component.ts
@@ -1,17 +1,104 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
-import { reports, weeklySales } from "../../core/mock-data";
+import { ChangeDetectorRef, Component, NgZone, OnInit } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { ReportsApiService, SalesReport } from "../../core/services/reports-api.service";
 import { formatCurrency } from "../../core/utils/format";
 
 @Component({
   selector: "pf-reports",
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: "./reports.component.html",
   styleUrl: "./reports.component.css"
 })
-export class ReportsComponent {
-  readonly reports = reports;
-  readonly weeklySales = weeklySales;
+export class ReportsComponent implements OnInit {
+  dataInicio = "";
+  dataFim = "";
+  isLoading = true;
+  errorMessage = "";
+  report: SalesReport = this.getEmptyReport();
   readonly formatCurrency = formatCurrency;
+
+  constructor(
+    private readonly reportsApiService: ReportsApiService,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly ngZone: NgZone,
+  ) {}
+
+  ngOnInit(): void {
+    this.loadReport();
+  }
+
+  get growthLabel(): string {
+    const values = this.report.dailySales;
+
+    if (values.length < 2) {
+      return "0%";
+    }
+
+    const midpoint = Math.floor(values.length / 2);
+    const previous = values.slice(0, midpoint).reduce((sum, item) => sum + item.value, 0);
+    const current = values.slice(midpoint).reduce((sum, item) => sum + item.value, 0);
+
+    if (previous <= 0) {
+      return current > 0 ? "+100%" : "0%";
+    }
+
+    const growth = ((current - previous) / previous) * 100;
+
+    return `${growth >= 0 ? "+" : ""}${growth.toFixed(0)}%`;
+  }
+
+  get maxDailyValue(): number {
+    return Math.max(...this.report.dailySales.map((item) => item.value), 1);
+  }
+
+  getBarHeight(value: number): number {
+    return Math.max((value / this.maxDailyValue) * 180, 20);
+  }
+
+  applyFilters(): void {
+    this.loadReport();
+  }
+
+  retry(): void {
+    this.loadReport();
+  }
+
+  private loadReport(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.changeDetectorRef.detectChanges();
+
+    this.reportsApiService.getSalesReport({
+      dataInicio: this.dataInicio,
+      dataFim: this.dataFim,
+    }).subscribe({
+      next: (report) => {
+        this.ngZone.run(() => {
+          this.report = report;
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+      error: () => {
+        this.ngZone.run(() => {
+          this.report = this.getEmptyReport();
+          this.errorMessage = "API de relatorios indisponivel. Nao ha fallback mockado nesta tela.";
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+    });
+  }
+
+  private getEmptyReport(): SalesReport {
+    return {
+      totalSold: 0,
+      totalOrders: 0,
+      averageTicket: 0,
+      dailySales: [],
+      topProducts: [],
+    };
+  }
 }

--- a/apps/web/src/app/features/sale/sale.component.css
+++ b/apps/web/src/app/features/sale/sale.component.css
@@ -4,6 +4,16 @@
   gap: 1rem;
 }
 
+.sale-fallback-note {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid #fed7aa;
+  background: #fff7ed;
+  color: #9a3412;
+}
+
 .pdv-left,
 .pdv-right,
 .items-body,
@@ -76,6 +86,12 @@
   color: var(--green-dark);
 }
 
+.sale-contract-note {
+  display: grid;
+  gap: 0.4rem;
+  background: #f8fafc;
+}
+
 .pdv-status-bar {
   display: flex;
   justify-content: space-between;
@@ -100,5 +116,10 @@
 @media (max-width: 1100px) {
   .pdv-layout {
     grid-template-columns: 1fr;
+  }
+
+  .sale-fallback-note {
+    align-items: stretch;
+    flex-direction: column;
   }
 }

--- a/apps/web/src/app/features/sale/sale.component.html
+++ b/apps/web/src/app/features/sale/sale.component.html
@@ -5,6 +5,13 @@
       <input class="scanner-input" placeholder="Escaneie o codigo ou digite o nome do produto..." [(ngModel)]="search" />
     </div>
 
+    <div *ngIf="isLoading" class="panel empty-state">Carregando clientes e produtos da API...</div>
+
+    <div *ngIf="!isLoading && isUsingFallbackData" class="panel sale-fallback-note">
+      <div>{{ fallbackMessage }}</div>
+      <button class="btn-secondary compact" type="button" (click)="retry()">Tentar API novamente</button>
+    </div>
+
     <div class="panel items-panel">
       <div class="items-header">
         <div class="items-title">Itens da venda</div>
@@ -42,7 +49,7 @@
         <div *ngFor="let product of catalog" class="catalog-item">
           <div>
             <strong>{{ product.name }}</strong>
-            <div class="client-time">COD: {{ product.sku }} | Estoque {{ product.stock }} {{ product.unit }}</div>
+            <div class="client-time">COD: {{ product.sku }} | Categoria: {{ product.category }}</div>
           </div>
           <div class="toolbar">
             <strong>{{ formatCurrency(product.price) }}</strong>
@@ -86,9 +93,16 @@
       <button class="btn-secondary" type="button">Buscar produto</button>
     </div>
 
+    <div class="payment-panel sale-contract-note">
+      <div class="payment-label">Status da integracao</div>
+      <div class="client-time">
+        Clientes e produtos ja tentam leitura da API. O fechamento da venda ainda permanece local porque o backend exige `funcionarioId` e payload operacional completo.
+      </div>
+    </div>
+
     <div class="pdv-finalize-area">
       <button class="btn-cancel" type="button" (click)="cart = []">Cancelar</button>
-      <button class="btn-finalize" type="button" (click)="finalizeSale()">Finalizar</button>
+      <button class="btn-finalize" type="button" (click)="finalizeSale()">Finalizar localmente</button>
     </div>
 
     <div class="pdv-status-bar">

--- a/apps/web/src/app/features/sale/sale.component.html
+++ b/apps/web/src/app/features/sale/sale.component.html
@@ -7,8 +7,8 @@
 
     <div *ngIf="isLoading" class="panel empty-state">Carregando clientes e produtos da API...</div>
 
-    <div *ngIf="!isLoading && isUsingFallbackData" class="panel sale-fallback-note">
-      <div>{{ fallbackMessage }}</div>
+    <div *ngIf="!isLoading && errorMessage" class="panel sale-fallback-note">
+      <div>{{ errorMessage }}</div>
       <button class="btn-secondary compact" type="button" (click)="retry()">Tentar API novamente</button>
     </div>
 
@@ -48,11 +48,11 @@
       <div class="catalog-list">
         <div *ngFor="let product of catalog" class="catalog-item">
           <div>
-            <strong>{{ product.name }}</strong>
-            <div class="client-time">COD: {{ product.sku }} | Categoria: {{ product.category }}</div>
+            <strong>{{ product.nome || product.name }}</strong>
+            <div class="client-time">COD: {{ product.codigoBarras || product.sku }} | Categoria: {{ product.categoria || product.category }}</div>
           </div>
           <div class="toolbar">
-            <strong>{{ formatCurrency(product.price) }}</strong>
+            <strong>{{ formatCurrency(product.precoBase || product.price) }}</strong>
             <button class="btn-primary" type="button" (click)="addProduct(product)">Adicionar</button>
           </div>
         </div>
@@ -74,7 +74,7 @@
       <div class="payment-label">Identificar cliente</div>
       <select class="form-select" [(ngModel)]="selectedClientId">
         <option value="">Cliente balcao</option>
-        <option *ngFor="let client of clients" [value]="client.id">{{ client.name }}</option>
+        <option *ngFor="let client of clients" [value]="client.id">{{ client.nome || client.name }}</option>
       </select>
     </div>
 
@@ -96,13 +96,15 @@
     <div class="payment-panel sale-contract-note">
       <div class="payment-label">Status da integracao</div>
       <div class="client-time">
-        Clientes e produtos ja tentam leitura da API. O fechamento da venda ainda permanece local porque o backend exige `funcionarioId` e payload operacional completo.
+        Clientes, produtos e fechamento de venda usam API. O operador ainda usa `funcionarioId` fixo ate a autenticacao retornar o funcionario logado.
       </div>
     </div>
 
     <div class="pdv-finalize-area">
       <button class="btn-cancel" type="button" (click)="cart = []">Cancelar</button>
-      <button class="btn-finalize" type="button" (click)="finalizeSale()">Finalizar localmente</button>
+      <button class="btn-finalize" type="button" [disabled]="isSubmitting" (click)="finalizeSale()">
+        {{ isSubmitting ? 'Finalizando...' : 'Finalizar venda' }}
+      </button>
     </div>
 
     <div class="pdv-status-bar">

--- a/apps/web/src/app/features/sale/sale.component.ts
+++ b/apps/web/src/app/features/sale/sale.component.ts
@@ -1,10 +1,12 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { Router } from "@angular/router";
-import { clients, products } from "../../core/mock-data";
+import { clients as mockClients, products as mockProducts } from "../../core/mock-data";
 import { StorageService } from "../../core/services/storage.service";
-import { Product } from "../../core/models";
+import { Client, Product } from "../../core/models";
+import { ClientsApiService } from "../../core/services/clients-api.service";
+import { ProductsApiService } from "../../core/services/products-api.service";
 import { formatCurrency } from "../../core/utils/format";
 
 @Component({
@@ -14,21 +16,32 @@ import { formatCurrency } from "../../core/utils/format";
   templateUrl: "./sale.component.html",
   styleUrl: "./sale.component.css"
 })
-export class SaleComponent {
+export class SaleComponent implements OnInit {
   search = "";
   selectedClientId = "";
   payment = "PIX";
   discount = 0;
   cart: Array<{ id: number; name: string; price: number; quantity: number }> = [];
+  clients: Client[] = [];
+  products: Product[] = [];
+  isLoading = true;
+  errorMessage = "";
+  isUsingFallbackData = false;
+  fallbackMessage = "";
+  readonly canPersistSaleToApi = false;
 
-  readonly clients = clients;
-  readonly products = products;
   readonly formatCurrency = formatCurrency;
 
   constructor(
     private readonly storageService: StorageService,
-    private readonly router: Router
+    private readonly router: Router,
+    private readonly clientsApiService: ClientsApiService,
+    private readonly productsApiService: ProductsApiService,
   ) {}
+
+  ngOnInit(): void {
+    this.loadDependencies();
+  }
 
   get catalog() {
     const normalized = this.search.toLowerCase();
@@ -39,6 +52,10 @@ export class SaleComponent {
 
   get subtotal(): number {
     return this.cart.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  }
+
+  retry(): void {
+    this.loadDependencies();
   }
 
   addProduct(product: Product): void {
@@ -78,5 +95,53 @@ export class SaleComponent {
     });
 
     this.router.navigateByUrl("/historico");
+  }
+
+  private loadDependencies(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.isUsingFallbackData = false;
+    this.fallbackMessage = "";
+
+    let pending = 2;
+    let hasApiFailure = false;
+
+    const finish = () => {
+      pending -= 1;
+
+      if (pending === 0) {
+        this.isLoading = false;
+
+        if (hasApiFailure) {
+          this.isUsingFallbackData = true;
+          this.fallbackMessage =
+            "API de clientes/produtos indisponivel no momento. Mantendo fallback local para validacao da tela de vendas.";
+        }
+      }
+    };
+
+    this.clientsApiService.listClients().subscribe({
+      next: (clients) => {
+        this.clients = clients;
+        finish();
+      },
+      error: () => {
+        hasApiFailure = true;
+        this.clients = mockClients;
+        finish();
+      },
+    });
+
+    this.productsApiService.listProducts().subscribe({
+      next: (products) => {
+        this.products = products;
+        finish();
+      },
+      error: () => {
+        hasApiFailure = true;
+        this.products = mockProducts;
+        finish();
+      },
+    });
   }
 }

--- a/apps/web/src/app/features/sale/sale.component.ts
+++ b/apps/web/src/app/features/sale/sale.component.ts
@@ -2,11 +2,10 @@ import { CommonModule } from "@angular/common";
 import { Component, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { Router } from "@angular/router";
-import { clients as mockClients, products as mockProducts } from "../../core/mock-data";
-import { StorageService } from "../../core/services/storage.service";
 import { Client, Product } from "../../core/models";
 import { ClientsApiService } from "../../core/services/clients-api.service";
 import { ProductsApiService } from "../../core/services/products-api.service";
+import { SalesApiService } from "../../core/services/sales-api.service";
 import { formatCurrency } from "../../core/utils/format";
 
 @Component({
@@ -25,18 +24,16 @@ export class SaleComponent implements OnInit {
   clients: Client[] = [];
   products: Product[] = [];
   isLoading = true;
+  isSubmitting = false;
   errorMessage = "";
-  isUsingFallbackData = false;
-  fallbackMessage = "";
-  readonly canPersistSaleToApi = false;
 
   readonly formatCurrency = formatCurrency;
 
   constructor(
-    private readonly storageService: StorageService,
     private readonly router: Router,
     private readonly clientsApiService: ClientsApiService,
     private readonly productsApiService: ProductsApiService,
+    private readonly salesApiService: SalesApiService,
   ) {}
 
   ngOnInit(): void {
@@ -46,7 +43,10 @@ export class SaleComponent implements OnInit {
   get catalog() {
     const normalized = this.search.toLowerCase();
     return this.products
-      .filter((product) => product.name.toLowerCase().includes(normalized) || product.sku.includes(this.search))
+      .filter((product) =>
+        (product.nome ?? product.name).toLowerCase().includes(normalized) ||
+        (product.codigoBarras ?? product.sku).includes(this.search),
+      )
       .slice(0, 6);
   }
 
@@ -64,7 +64,15 @@ export class SaleComponent implements OnInit {
       existing.quantity += 1;
       return;
     }
-    this.cart = [...this.cart, { id: product.id, name: product.name, price: product.price, quantity: 1 }];
+    this.cart = [
+      ...this.cart,
+      {
+        id: product.id,
+        name: product.nome ?? product.name,
+        price: Number(product.precoBase ?? product.price),
+        quantity: 1,
+      },
+    ];
   }
 
   updateQuantity(id: number, delta: number): void {
@@ -82,26 +90,33 @@ export class SaleComponent implements OnInit {
       return;
     }
 
-    const client = this.clients.find((item) => item.id === Number(this.selectedClientId));
-    const currentSales = this.storageService.getSales();
-    this.storageService.appendSale({
-      id: `#VEN-${9403 + currentSales.length}`,
-      datetime: "Agora mesmo",
-      client: client ? client.name : "Cliente balcao",
-      mainProduct: this.cart[0].name,
-      payment: this.payment,
-      value: Math.max(this.subtotal - this.discount, 0),
-      status: this.payment === "Fiado" ? "Pendente" : "Concluida"
-    });
+    this.isSubmitting = true;
+    this.errorMessage = "";
 
-    this.router.navigateByUrl("/historico");
+    this.salesApiService.createSale({
+      funcionarioId: 1,
+      clienteId: this.selectedClientId ? Number(this.selectedClientId) : null,
+      formaPagamento: this.toFormaPagamento(this.payment),
+      status: "CONCLUIDA",
+      itens: this.cart.map((item) => ({
+        produtoId: item.id,
+        quantidade: item.quantity,
+      })),
+    }).subscribe({
+      next: () => {
+        this.isSubmitting = false;
+        this.router.navigateByUrl("/historico");
+      },
+      error: () => {
+        this.isSubmitting = false;
+        this.errorMessage = "Nao foi possivel finalizar a venda na API.";
+      },
+    });
   }
 
   private loadDependencies(): void {
     this.isLoading = true;
     this.errorMessage = "";
-    this.isUsingFallbackData = false;
-    this.fallbackMessage = "";
 
     let pending = 2;
     let hasApiFailure = false;
@@ -113,9 +128,7 @@ export class SaleComponent implements OnInit {
         this.isLoading = false;
 
         if (hasApiFailure) {
-          this.isUsingFallbackData = true;
-          this.fallbackMessage =
-            "API de clientes/produtos indisponivel no momento. Mantendo fallback local para validacao da tela de vendas.";
+          this.errorMessage = "API de clientes/produtos indisponivel. Nao ha fallback mockado na tela de venda.";
         }
       }
     };
@@ -127,7 +140,7 @@ export class SaleComponent implements OnInit {
       },
       error: () => {
         hasApiFailure = true;
-        this.clients = mockClients;
+        this.clients = [];
         finish();
       },
     });
@@ -139,9 +152,21 @@ export class SaleComponent implements OnInit {
       },
       error: () => {
         hasApiFailure = true;
-        this.products = mockProducts;
+        this.products = [];
         finish();
       },
     });
+  }
+
+  private toFormaPagamento(payment: string): string {
+    const paymentMap: Record<string, string> = {
+      Dinheiro: "DINHEIRO",
+      Credito: "CREDITO",
+      Debito: "DEBITO",
+      PIX: "PIX",
+      Fiado: "FIADO",
+    };
+
+    return paymentMap[payment] ?? payment;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,8 @@
         "@angular/forms": "^21.0.0",
         "@angular/platform-browser": "^21.0.0",
         "@angular/router": "^21.0.0",
+        "@fundamental-ngx/ui5-webcomponents": "^0.62.2",
+        "@ui5/webcomponents": "^2.22.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.8.1",
         "zone.js": "~0.15.0"
@@ -860,6 +862,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@angular/cdk": {
+      "version": "21.2.11",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.11.tgz",
+      "integrity": "sha512-QS5f0si1LgDQFgxXtpuDr7gBFVSQLl1fdnx3UA6GrzSmuV0sfzBhBq7NlZGxZTDaKy4ZxY34RFx4Bvm1zo+gBA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "parse5": "^8.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^21.0.0 || ^22.0.0",
+        "@angular/core": "^21.0.0 || ^22.0.0",
+        "@angular/platform-browser": "^21.0.0 || ^22.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/cli": {
@@ -3315,6 +3334,201 @@
         "node": ">=18"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
+      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.2",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
+      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/icu-skeleton-parser": "1.8.16",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
+      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
+      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@fundamental-ngx/cdk": {
+      "version": "0.62.2",
+      "resolved": "https://registry.npmjs.org/@fundamental-ngx/cdk/-/cdk-0.62.2.tgz",
+      "integrity": "sha512-cLK8Hd4nMvxwYb2Ba5aVZY6WLAXb0uRdKrUHnYZOcwXJKI017DobZJrh4OO1CY6cjy5dAfDy/aBjo+GoQ6tZZw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@fundamental-styles/cx": "0.41.6",
+        "@sap-theming/theming-base-content": "^11.35.0",
+        "compare-versions": "^6.1.0",
+        "fast-equals": "^6.0.0",
+        "focus-trap": "^7.1.0",
+        "fundamental-styles": "0.41.6",
+        "lodash-es": "^4.17.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "^21.0.0",
+        "@angular/common": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@angular/forms": "^21.0.0",
+        "@angular/platform-browser": "^21.0.0",
+        "@angular/router": "^21.0.0",
+        "rxjs": "^7.8.0"
+      }
+    },
+    "node_modules/@fundamental-ngx/core": {
+      "version": "0.62.2",
+      "resolved": "https://registry.npmjs.org/@fundamental-ngx/core/-/core-0.62.2.tgz",
+      "integrity": "sha512-kXsGwtAMfaI9eLzSzScDZ2bXdBflPF0NmeLHdtAIK8nQcNs/QtW6M36os2Hnv5HYiSe7cALmIPrp0sKj/nUsTQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "compare-versions": "^6.1.0",
+        "fast-equals": "^6.0.0",
+        "focus-trap": "^7.1.0",
+        "lodash-es": "^4.17.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "^21.0.0",
+        "@angular/common": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@angular/forms": "^21.0.0",
+        "@angular/platform-browser": "^21.0.0",
+        "@angular/router": "^21.0.0",
+        "@fundamental-ngx/cdk": "0.62.2",
+        "@fundamental-ngx/i18n": "0.62.2",
+        "@sap-theming/theming-base-content": "^11.35.0",
+        "fundamental-styles": "0.41.6",
+        "rxjs": "^7.8.0"
+      }
+    },
+    "node_modules/@fundamental-ngx/i18n": {
+      "version": "0.62.2",
+      "resolved": "https://registry.npmjs.org/@fundamental-ngx/i18n/-/i18n-0.62.2.tgz",
+      "integrity": "sha512-tU56zw6S0O3emN2cqXv7GwrK+Ci5tJQn3pXcjra3bLzUoKhcNDvC4myls72tQmnWbYK5gualmZt1pedaJ+CegQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "fast-equals": "^6.0.0",
+        "intl-messageformat": "^10.5.0",
+        "lodash-es": "^4.17.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@fundamental-ngx/cdk": "0.62.2",
+        "rxjs": "^7.8.0"
+      }
+    },
+    "node_modules/@fundamental-ngx/ui5-webcomponents": {
+      "version": "0.62.2",
+      "resolved": "https://registry.npmjs.org/@fundamental-ngx/ui5-webcomponents/-/ui5-webcomponents-0.62.2.tgz",
+      "integrity": "sha512-gIQZlb246ffmXPAHlwjC7VxRHNQON9vAOJJWaWIfJd4VsjnAXOuJu2FPDlvbegfJFxbqwXM5WPwC2yXzJ0QnlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@fundamental-ngx/ui5-webcomponents-base": "0.62.2",
+        "@sap-theming/theming-base-content": "^11.35.0",
+        "compare-versions": "^6.1.0",
+        "fast-equals": "^6.0.0",
+        "lodash-es": "^4.17.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "^21.0.0",
+        "@angular/common": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@angular/forms": "^21.0.0",
+        "@angular/platform-browser": "^21.0.0",
+        "@angular/router": "^21.0.0",
+        "@fundamental-ngx/core": "0.62.2",
+        "@ui5/webcomponents": "^2.22.0",
+        "fundamental-styles": "0.41.6",
+        "rxjs": "^7.8.0"
+      }
+    },
+    "node_modules/@fundamental-ngx/ui5-webcomponents-base": {
+      "version": "0.62.2",
+      "resolved": "https://registry.npmjs.org/@fundamental-ngx/ui5-webcomponents-base/-/ui5-webcomponents-base-0.62.2.tgz",
+      "integrity": "sha512-rXf4LttVua/fsqXkSRYWg45W/ZWWwR7z8B6JfPU97lmbNjE2G1riOgrT0pUoIQNmuPaPiizJEDHFwTgTWpiezQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "compare-versions": "^6.1.0",
+        "fast-equals": "^6.0.0",
+        "lodash-es": "^4.17.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "^21.0.0",
+        "@angular/common": "^21.0.0",
+        "@angular/core": "^21.0.0",
+        "@angular/forms": "^21.0.0",
+        "@angular/platform-browser": "^21.0.0",
+        "@angular/router": "^21.0.0",
+        "@fundamental-ngx/i18n": "0.62.2",
+        "@ui5/webcomponents-base": "^2.22.0",
+        "fundamental-styles": "0.41.6",
+        "rxjs": "^7.8.0"
+      }
+    },
+    "node_modules/@fundamental-styles/common-css": {
+      "version": "0.41.6",
+      "resolved": "https://registry.npmjs.org/@fundamental-styles/common-css/-/common-css-0.41.6.tgz",
+      "integrity": "sha512-Ul8kIH3nBPYJRu4E7zgq3c3pYwzOidvvD7XUB+/20xNLmVTc5zaVJko6kasx6hSI5SE3UHWLIK2fdJN8Qzhtqg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@sap-theming/theming-base-content": "^11.35.0"
+      }
+    },
+    "node_modules/@fundamental-styles/cx": {
+      "version": "0.41.6",
+      "resolved": "https://registry.npmjs.org/@fundamental-styles/cx/-/cx-0.41.6.tgz",
+      "integrity": "sha512-2dFk9JfgJycQnR9nSgWLoV3DgTLz8GuXkB+CKp+zTYaqRn+twc1prBHu+oCICkQ0deqk5ZJ7hEh6EkK5fQYLfA==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
     "node_modules/@gar/promise-retry": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
@@ -4240,6 +4454,12 @@
         "@inquirer/prompts": ">= 3 < 8",
         "listr2": "9.0.5"
       }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@lmdb/lmdb-darwin-arm64": {
       "version": "3.5.1",
@@ -6498,6 +6718,12 @@
         "win32"
       ]
     },
+    "node_modules/@sap-theming/theming-base-content": {
+      "version": "11.35.1",
+      "resolved": "https://registry.npmjs.org/@sap-theming/theming-base-content/-/theming-base-content-11.35.1.tgz",
+      "integrity": "sha512-D2Z9sSlUO8FGHO5RZh70Jr1VsHrWxpbxCPK9gXqOP+dD27hzufSll8HCXRddi30uJmQ/oBQchCef0DKWSD/e8g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@schematics/angular": {
       "version": "21.2.9",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-21.2.9.tgz",
@@ -6835,6 +7061,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/jquery": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.34.tgz",
+      "integrity": "sha512-3m3939S3erqmTLJANS/uy0B6V7BorKx7RorcGZVjZ62dF5PAGbKEDZK1CuLtKombJkFA2T1jl8LAIIs7IV6gBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -6858,6 +7093,16 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/openui5": {
+      "version": "1.148.0",
+      "resolved": "https://registry.npmjs.org/@types/openui5/-/openui5-1.148.0.tgz",
+      "integrity": "sha512-fPQQfKMsOQjYgPothnvpfzMzFSsKh02UwNH++aXAikTshBGLIxu2OhrxjTtrMAdmce8hSvAmvwFFAehcM7kNxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jquery": "~3.5.13",
+        "@types/qunit": "^2.5.4"
+      }
+    },
     "node_modules/@types/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
@@ -6874,6 +7119,12 @@
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
       "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/qunit": {
+      "version": "2.19.14",
+      "resolved": "https://registry.npmjs.org/@types/qunit/-/qunit-2.19.14.tgz",
+      "integrity": "sha512-ou2RMtwyDnW1btrMnDMZeL6V5/yRRbuHKrRC6y8IuzDljjVzw6wPCVFb8p4qJD0NkUkf3BdZeJJIBzjK1BUUDQ==",
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
@@ -6944,6 +7195,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
+      "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
+      "license": "MIT"
+    },
     "node_modules/@types/sockjs": {
       "version": "0.3.36",
       "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
@@ -6954,6 +7211,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -6963,6 +7226,91 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@ui5/webcomponents": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents/-/webcomponents-2.22.0.tgz",
+      "integrity": "sha512-3rasr8HXHhEE3ojvPJNSpQkbyqdHPidflUqYjLMnU+39pZMITima5qRmbI9z/ekfcGifVoq2iBVxi4Yj2XY5Qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ui5/webcomponents-base": "2.22.0",
+        "@ui5/webcomponents-icons": "2.22.0",
+        "@ui5/webcomponents-icons-business-suite": "2.22.0",
+        "@ui5/webcomponents-icons-tnt": "2.22.0",
+        "@ui5/webcomponents-localization": "2.22.0",
+        "@ui5/webcomponents-theming": "2.22.0"
+      }
+    },
+    "node_modules/@ui5/webcomponents-base": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-base/-/webcomponents-base-2.22.0.tgz",
+      "integrity": "sha512-bN0Nrq7knbhqoB+h6R+ns3rZ//SBMQOX5Uvxs8g+yRoWQWfQEBquTmzaYw2n1Ev4j8NheKnq1aqT0Tgo26W1Ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.2",
+        "lit-html": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ui5/webcomponents-icons": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-icons/-/webcomponents-icons-2.22.0.tgz",
+      "integrity": "sha512-DHGlHW4ai7GpnZU2sPOsv6GiIhvHUz1Vfipe823MnT+ox/O801u7XlNn/ShrxV3KIbxy14b2ZEKFk87RFkySvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ui5/webcomponents-base": "2.22.0"
+      }
+    },
+    "node_modules/@ui5/webcomponents-icons-business-suite": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-icons-business-suite/-/webcomponents-icons-business-suite-2.22.0.tgz",
+      "integrity": "sha512-CxgYxDLvumbhNIvyLleTrlHt9FxrAwkwPhkZc6GQ3yEA9gTvyiJuHU7lbeTvvPR8bzZLamq5JL2sLrAV+edChA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ui5/webcomponents-base": "2.22.0"
+      }
+    },
+    "node_modules/@ui5/webcomponents-icons-tnt": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-icons-tnt/-/webcomponents-icons-tnt-2.22.0.tgz",
+      "integrity": "sha512-CMblqRW7/v3PwUEhcsvRtP9jRJkvxqbqPHl7B5FrJswf5KcoPLY7jzRP9sL8LvYbBbni3YMYNIvzLJsA1xNhpA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ui5/webcomponents-base": "2.22.0"
+      }
+    },
+    "node_modules/@ui5/webcomponents-localization": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-localization/-/webcomponents-localization-2.22.0.tgz",
+      "integrity": "sha512-GzUKxob1pFikH5bfJi+ASFMoVKY5djS/Gah7WvoXyr3Zl9rSfygNhKA4oMo00c6fWOFnpV+l3kdQxB0jMh78Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/openui5": "^1.146.0",
+        "@ui5/webcomponents-base": "2.22.0"
+      }
+    },
+    "node_modules/@ui5/webcomponents-theming": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@ui5/webcomponents-theming/-/webcomponents-theming-2.22.0.tgz",
+      "integrity": "sha512-W/7PZITrfuxPqV4qAe9uEdale2PU3fgSbtN234qWXv971C/rqAHYynSesMSXqaJ4eJAED0yYdTVjJU1syP8CDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sap-theming/theming-base-content": "11.35.0",
+        "@ui5/webcomponents-base": "2.22.0"
+      }
+    },
+    "node_modules/@ui5/webcomponents-theming/node_modules/@sap-theming/theming-base-content": {
+      "version": "11.35.0",
+      "resolved": "https://registry.npmjs.org/@sap-theming/theming-base-content/-/theming-base-content-11.35.0.tgz",
+      "integrity": "sha512-+eGmyVyzEA+snJRCvN9O45N2vavUElwZdlPZgWOJ/PNUkwKgoug6o1w1DZmFOhhqyQ9Gt0QGBJBXlGAvJ2TjPg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
       "version": "2.1.4",
@@ -8199,6 +8547,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -8596,6 +8950,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
@@ -9275,6 +9636,15 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/fast-equals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-6.0.0.tgz",
+      "integrity": "sha512-PFhhIGgdM79r5Uztdj9Zb6Tt1zKafqVfdMGwVca1z5z6fbX7DmsySSuJd8HiP6I1j505DCS83cLxo5rmSNeVEA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -9364,6 +9734,16 @@
       "license": "BSD-3-Clause",
       "bin": {
         "flat": "cli.js"
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tabbable": "^6.4.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -9471,6 +9851,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fundamental-styles": {
+      "version": "0.41.6",
+      "resolved": "https://registry.npmjs.org/fundamental-styles/-/fundamental-styles-0.41.6.tgz",
+      "integrity": "sha512-NpyV6j4adoKSydZi2UE7hc4hBv6RV6DAbgGLKxQEeloQ0+0C3ZKR/0BRNy5QaSumzlBg3xaW/nM4dVUJwykilg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "peerDependencies": {
+        "@fundamental-styles/common-css": "0.41.6",
+        "@sap-theming/theming-base-content": "^11.35.0"
       }
     },
     "node_modules/generate-function": {
@@ -10041,6 +10432,19 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.18",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
+      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.6",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.4",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/ip-address": {
@@ -10663,6 +11067,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/lmdb": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-3.5.1.tgz",
@@ -10731,6 +11144,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -12054,7 +12473,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
       "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^8.0.0"
@@ -12108,7 +12526,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
       "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20.19.0"
@@ -14098,6 +14515,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",


### PR DESCRIPTION
## Resumo
Evolui o frontend Angular e o backend para consumir contratos reais do banco em clientes, produtos, fiado, vendas, funcionarios, historico, dashboard e relatorios, removendo mocks das telas integradas.

## O que entra neste PR
- HttpClient habilitado no Angular
- Services para clientes, produtos, vendas, funcionarios, fiado e relatorios
- Clientes com CRUD via API, CPF obrigatório, consulta Serasa fake, busca e paginacao no backend
- Produtos com CRUD via API, categorias reais, busca por código de barras, filtro/busca/paginacao no backend e UI5 FileUploader no modal
- Funcionarios com listagem, busca, paginacao, cadastro, edicao e exclusao via API seguindo o contrato da documentacao
- Fiado com CRUD dedicado em `/api/fiado`, listagem de devedores e registro de cobranca no banco
- Nova venda enviando `POST /api/vendas` e backend calculando total/subtotal com transacao Prisma
- Historico de vendas consumindo `GET /api/vendas` com filtros de periodo/funcionario, paginacao e summary
- Cancelamento formal de venda via `PATCH /api/vendas/:id/cancelar`
- Relatorios reais via `/api/relatorios/vendas`, `/api/relatorios/devedores` e `/api/relatorios/dashboard`
- Dashboard consumindo KPIs e ultimas vendas da API
- Backend com alias `/api/*`, `Cache-Control: no-store`, filtros de registros ativos e senha de funcionario sempre hasheada no backend
- Produtos lazy-loaded para reduzir bundle inicial

## Observacoes
- `funcionarioId` na venda ainda esta fixo como `1` ate a autenticacao devolver o funcionario logado
- FileUploader ainda gera preview/Data URL local; upload real para storage fica para proxima etapa
- Permissoes por role ainda dependem de aplicar auth/JWT nas rotas
- Sub-recursos de funcionarios ainda pendentes: ponto, ferias, licencas e atestados
- Câmeras, Chatbot, Configuracoes e Login seguem fora deste recorte

## Validacao
- `npm run build:web`
- `npm run prisma:validate`
- Teste local de `GET /api/clientes?busca=&page=1&limit=2`
- Teste local de `GET /api/produtos?busca=&page=1&limit=2`
- Teste local de `GET /api/fiado`
- Teste local de `GET /api/vendas?page=1&limit=2`
- Teste local de `GET /api/funcionarios?busca=&page=1&limit=2`
- Teste local de `/api/relatorios/vendas`, `/api/relatorios/dashboard`, `/api/relatorios/devedores`