### PR TITLE
feat(auth): integra Supabase Auth e reforca senhas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 coverage/
 apps/api/src/generated/
 apps/web/.angular/
+*.log
 
 .env
 .env.*

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -22,7 +22,14 @@ JWT_EXPIRES_IN="1d"
 
 # URL pública do projeto Supabase, usada futuramente para montar URLs de arquivos.
 SUPABASE_PROJECT_URL="https://your-project.supabase.co"
+# Chave anon/public usada no fluxo de login do Supabase Auth.
+SUPABASE_ANON_KEY="[YOUR-ANON-KEY]"
 # Chave administrativa para uploads server-side no bucket.
 SUPABASE_SERVICE_ROLE_KEY="[YOUR-SERVICE-ROLE-KEY]"
 # Nome do bucket público reservado para imagens de produtos.
 SUPABASE_STORAGE_BUCKET_PRODUTOS="produtos"
+# Senha temporaria forte usada para criar usuarios Auth a partir dos funcionarios seedados.
+# Troque em cada ambiente antes de rodar o seed.
+SUPABASE_AUTH_SEED_PASSWORD="PaoFresquim@2026!"
+# UUIDs do Supabase Auth que devem receber acesso administrativo mesmo se criados direto no painel.
+SUPABASE_ADMIN_USER_IDS=""

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,7 +13,8 @@
     "prisma:db:push": "prisma db push",
     "prisma:validate": "prisma validate",
     "prisma:seed": "node prisma/seed.js",
-    "storage:setup": "node scripts/setup-storage-produtos.js"
+    "storage:setup": "node scripts/setup-storage-produtos.js",
+    "auth:seed": "node scripts/seed-auth-users.js"
   },
   "devDependencies": {
     "nodemon": "^3.1.14",

--- a/apps/api/prisma/seed.js
+++ b/apps/api/prisma/seed.js
@@ -6,7 +6,7 @@ import { prisma } from "../src/config/prisma.js";
 
 // Cria os usuários base do sistema com senha hash para não gravar senha pura no banco.
 async function seedFuncionarios() {
-  const senhaHash = await bcrypt.hash("123456", 10);
+  const senhaHash = await bcrypt.hash("PaoFresquim@2026!", 10);
 
   // Conjunto mínimo de perfis para validar autenticação e permissões futuramente.
   const funcionarios = [

--- a/apps/api/scripts/seed-auth-users.js
+++ b/apps/api/scripts/seed-auth-users.js
@@ -1,0 +1,54 @@
+import "dotenv/config";
+
+import { prisma } from "../src/config/prisma.js";
+import { createSupabaseUser } from "../src/services/supabaseAuthService.js";
+import { validateStrongPassword } from "../src/utils/password.js";
+
+const defaultPassword = process.env.SUPABASE_AUTH_SEED_PASSWORD ?? "PaoFresquim@2026!";
+
+async function main() {
+  validateStrongPassword(defaultPassword, "SUPABASE_AUTH_SEED_PASSWORD");
+
+  const funcionarios = await prisma.funcionario.findMany({
+    where: { ativo: true },
+    select: {
+      nome: true,
+      email: true,
+      role: true,
+      cargo: true,
+    },
+  });
+
+  for (const funcionario of funcionarios) {
+    try {
+      await createSupabaseUser({
+        email: funcionario.email,
+        password: defaultPassword,
+        metadata: {
+          nome: funcionario.nome,
+          role: funcionario.role,
+          cargo: funcionario.cargo,
+        },
+      });
+      console.log(`Usuario Auth criado: ${funcionario.email}`);
+    } catch (error) {
+      const message = error?.message ?? "";
+
+      if (message.toLowerCase().includes("already") || message.toLowerCase().includes("registered")) {
+        console.log(`Usuario Auth ja existe: ${funcionario.email}`);
+        continue;
+      }
+
+      throw error;
+    }
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/apps/api/src/config/auth.js
+++ b/apps/api/src/config/auth.js
@@ -1,0 +1,12 @@
+export function getSupabaseAdminUserIds() {
+  return new Set(
+    (process.env.SUPABASE_ADMIN_USER_IDS ?? "")
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean),
+  );
+}
+
+export function isSupabaseAdminUser(userId) {
+  return getSupabaseAdminUserIds().has(userId);
+}

--- a/apps/api/src/middlewares/auth.js
+++ b/apps/api/src/middlewares/auth.js
@@ -1,0 +1,82 @@
+import { prisma } from "../config/prisma.js";
+import { isSupabaseAdminUser } from "../config/auth.js";
+import { getSupabaseUser } from "../services/supabaseAuthService.js";
+import { AppError } from "../utils/AppError.js";
+
+function getBearerToken(request) {
+  const header = request.headers.authorization ?? "";
+  const [scheme, token] = header.split(" ");
+
+  if (scheme !== "Bearer" || !token) {
+    throw new AppError("Token de autenticacao ausente.", 401);
+  }
+
+  return token;
+}
+
+export async function ensureAuth(request, _response, next) {
+  try {
+    const token = getBearerToken(request);
+    const supabaseUser = await getSupabaseUser(token);
+    const funcionario = await prisma.funcionario.findFirst({
+      where: {
+        email: supabaseUser.email,
+        ativo: true,
+      },
+      select: {
+        id: true,
+        nome: true,
+        email: true,
+        role: true,
+        cargo: true,
+      },
+    });
+
+    if (!funcionario && isSupabaseAdminUser(supabaseUser.id)) {
+      request.user = {
+        id: null,
+        nome: supabaseUser.email,
+        email: supabaseUser.email,
+        role: "PROPRIETARIO",
+        cargo: "Administrador",
+        supabaseUserId: supabaseUser.id,
+      };
+      return next();
+    }
+
+    if (!funcionario) {
+      throw new AppError("Funcionario autenticado nao encontrado no sistema.", 401);
+    }
+
+    request.user = {
+      ...funcionario,
+      role: isSupabaseAdminUser(supabaseUser.id) ? "PROPRIETARIO" : funcionario.role,
+      supabaseUserId: supabaseUser.id,
+    };
+    next();
+  } catch (error) {
+    next(error);
+  }
+}
+
+export function ensureRole(...roles) {
+  return (request, _response, next) => {
+    if (!request.user) {
+      return next(new AppError("Usuario nao autenticado.", 401));
+    }
+
+    if (!roles.includes(request.user.role)) {
+      return next(new AppError("Usuario sem permissao para esta operacao.", 403));
+    }
+
+    return next();
+  };
+}
+
+export function ensureFuncionarioLinked(request, _response, next) {
+  if (!request.user?.id) {
+    return next(new AppError("Usuario autenticado sem funcionario vinculado para esta operacao.", 403));
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/auth.routes.js
+++ b/apps/api/src/routes/auth.routes.js
@@ -1,0 +1,44 @@
+import { Router } from "express";
+
+import { ensureAuth } from "../middlewares/auth.js";
+import { atualizarSenhaUsuario, loginFuncionario, solicitarRedefinicaoSenha } from "../services/authService.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
+
+const authRoutes = Router();
+
+authRoutes.post(
+  "/login",
+  asyncHandler(async (request, response) => {
+    const auth = await loginFuncionario(request.body);
+
+    response.status(200).json(auth);
+  }),
+);
+
+authRoutes.get(
+  "/me",
+  ensureAuth,
+  asyncHandler(async (request, response) => {
+    response.status(200).json({ usuario: request.user });
+  }),
+);
+
+authRoutes.post(
+  "/password/recover",
+  asyncHandler(async (request, response) => {
+    const result = await solicitarRedefinicaoSenha(request.body);
+
+    response.status(200).json(result);
+  }),
+);
+
+authRoutes.post(
+  "/password/update",
+  asyncHandler(async (request, response) => {
+    const result = await atualizarSenhaUsuario(request.body);
+
+    response.status(200).json(result);
+  }),
+);
+
+export { authRoutes };

--- a/apps/api/src/routes/clientes.routes.js
+++ b/apps/api/src/routes/clientes.routes.js
@@ -8,11 +8,15 @@ import {
   updateCliente,
 } from "../services/clienteService.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
+import { ensureAuth, ensureRole } from "../middlewares/auth.js";
 
 const clientesRoutes = Router();
 
+clientesRoutes.use(ensureAuth);
+
 clientesRoutes.post(
   "/",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
   asyncHandler(async (request, response) => {
     const cliente = await createCliente(request.body);
 
@@ -22,6 +26,7 @@ clientesRoutes.post(
 
 clientesRoutes.get(
   "/",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
   asyncHandler(async (request, response) => {
     const clientes = await listClientes(request.query);
 
@@ -31,6 +36,7 @@ clientesRoutes.get(
 
 clientesRoutes.get(
   "/:id",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
   asyncHandler(async (request, response) => {
     const cliente = await getClienteById(request.params.id);
 
@@ -40,6 +46,7 @@ clientesRoutes.get(
 
 clientesRoutes.put(
   "/:id",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
   asyncHandler(async (request, response) => {
     const cliente = await updateCliente(request.params.id, request.body);
 
@@ -49,6 +56,7 @@ clientesRoutes.put(
 
 clientesRoutes.delete(
   "/:id",
+  ensureRole("PROPRIETARIO"),
   asyncHandler(async (request, response) => {
     await deleteCliente(request.params.id);
 

--- a/apps/api/src/routes/fiado.routes.js
+++ b/apps/api/src/routes/fiado.routes.js
@@ -9,11 +9,15 @@ import {
   updateContaFiado,
 } from "../services/fiadoService.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
+import { ensureAuth, ensureRole } from "../middlewares/auth.js";
 
 const fiadoRoutes = Router();
 
+fiadoRoutes.use(ensureAuth);
+
 fiadoRoutes.get(
   "/",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
   asyncHandler(async (_request, response) => {
     const contas = await listContasFiado();
 
@@ -23,6 +27,7 @@ fiadoRoutes.get(
 
 fiadoRoutes.post(
   "/",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
   asyncHandler(async (request, response) => {
     const conta = await createContaFiado(request.body);
 
@@ -32,6 +37,7 @@ fiadoRoutes.post(
 
 fiadoRoutes.get(
   "/:clienteId",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
   asyncHandler(async (request, response) => {
     const conta = await getContaFiadoByClienteId(request.params.clienteId);
 
@@ -41,6 +47,7 @@ fiadoRoutes.get(
 
 fiadoRoutes.put(
   "/:clienteId",
+  ensureRole("PROPRIETARIO"),
   asyncHandler(async (request, response) => {
     const conta = await updateContaFiado(request.params.clienteId, request.body);
 
@@ -50,6 +57,7 @@ fiadoRoutes.put(
 
 fiadoRoutes.post(
   "/:clienteId/cobranca",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
   asyncHandler(async (request, response) => {
     const conta = await registrarCobrancaFiado(request.params.clienteId);
 
@@ -59,6 +67,7 @@ fiadoRoutes.post(
 
 fiadoRoutes.delete(
   "/:clienteId",
+  ensureRole("PROPRIETARIO"),
   asyncHandler(async (request, response) => {
     await deleteContaFiado(request.params.clienteId);
 

--- a/apps/api/src/routes/funcionarios.routes.js
+++ b/apps/api/src/routes/funcionarios.routes.js
@@ -8,8 +8,11 @@ import {
   updateFuncionario,
 } from "../services/funcionarioService.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
+import { ensureAuth, ensureRole } from "../middlewares/auth.js";
 
 const funcionariosRoutes = Router();
+
+funcionariosRoutes.use(ensureAuth, ensureRole("PROPRIETARIO"));
 
 funcionariosRoutes.post(
   "/",

--- a/apps/api/src/routes/index.js
+++ b/apps/api/src/routes/index.js
@@ -1,5 +1,6 @@
 import { Router } from "express";
 
+import { authRoutes } from "./auth.routes.js";
 import { clientesRoutes } from "./clientes.routes.js";
 import { fiadoRoutes } from "./fiado.routes.js";
 import { funcionariosRoutes } from "./funcionarios.routes.js";
@@ -18,6 +19,7 @@ router.get("/health", (_request, response) => {
   });
 });
 
+router.use("/auth", authRoutes);
 router.use("/clientes", clientesRoutes);
 router.use("/produtos", produtosRoutes);
 router.use("/funcionarios", funcionariosRoutes);

--- a/apps/api/src/routes/produtos.routes.js
+++ b/apps/api/src/routes/produtos.routes.js
@@ -10,11 +10,15 @@ import {
   updateProduto,
 } from "../services/produtoService.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
+import { ensureAuth, ensureRole } from "../middlewares/auth.js";
 
 const produtosRoutes = Router();
 
+produtosRoutes.use(ensureAuth);
+
 produtosRoutes.post(
   "/",
+  ensureRole("PROPRIETARIO", "PADEIRO"),
   asyncHandler(async (request, response) => {
     const produto = await createProduto(request.body);
 
@@ -24,6 +28,7 @@ produtosRoutes.post(
 
 produtosRoutes.get(
   "/",
+  ensureRole("PROPRIETARIO", "ATENDENTE", "PADEIRO"),
   asyncHandler(async (request, response) => {
     const produtos = await listProdutos(request.query);
 
@@ -33,6 +38,7 @@ produtosRoutes.get(
 
 produtosRoutes.get(
   "/categorias",
+  ensureRole("PROPRIETARIO", "ATENDENTE", "PADEIRO"),
   asyncHandler(async (_request, response) => {
     const categorias = await listProdutoCategorias();
 
@@ -42,6 +48,7 @@ produtosRoutes.get(
 
 produtosRoutes.get(
   "/codigo/:codigoBarras",
+  ensureRole("PROPRIETARIO", "ATENDENTE", "PADEIRO"),
   asyncHandler(async (request, response) => {
     const produto = await getProdutoByCodigoBarras(request.params.codigoBarras);
 
@@ -51,6 +58,7 @@ produtosRoutes.get(
 
 produtosRoutes.get(
   "/:id",
+  ensureRole("PROPRIETARIO", "ATENDENTE", "PADEIRO"),
   asyncHandler(async (request, response) => {
     const produto = await getProdutoById(request.params.id);
 
@@ -60,6 +68,7 @@ produtosRoutes.get(
 
 produtosRoutes.put(
   "/:id",
+  ensureRole("PROPRIETARIO", "PADEIRO"),
   asyncHandler(async (request, response) => {
     const produto = await updateProduto(request.params.id, request.body);
 
@@ -69,6 +78,7 @@ produtosRoutes.put(
 
 produtosRoutes.delete(
   "/:id",
+  ensureRole("PROPRIETARIO"),
   asyncHandler(async (request, response) => {
     await deleteProduto(request.params.id);
 

--- a/apps/api/src/routes/relatorios.routes.js
+++ b/apps/api/src/routes/relatorios.routes.js
@@ -6,8 +6,11 @@ import {
   getRelatorioVendas,
 } from "../services/relatorioService.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
+import { ensureAuth, ensureRole } from "../middlewares/auth.js";
 
 const relatoriosRoutes = Router();
+
+relatoriosRoutes.use(ensureAuth, ensureRole("PROPRIETARIO"));
 
 relatoriosRoutes.get(
   "/vendas",

--- a/apps/api/src/routes/vendas.routes.js
+++ b/apps/api/src/routes/vendas.routes.js
@@ -9,13 +9,21 @@ import {
   updateVenda,
 } from "../services/vendaService.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
+import { ensureAuth, ensureFuncionarioLinked, ensureRole } from "../middlewares/auth.js";
 
 const vendasRoutes = Router();
 
+vendasRoutes.use(ensureAuth);
+
 vendasRoutes.post(
   "/",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
+  ensureFuncionarioLinked,
   asyncHandler(async (request, response) => {
-    const venda = await createVenda(request.body);
+    const venda = await createVenda({
+      ...request.body,
+      funcionarioId: request.user.id,
+    });
 
     response.status(201).json(venda);
   }),
@@ -23,6 +31,7 @@ vendasRoutes.post(
 
 vendasRoutes.get(
   "/",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
   asyncHandler(async (request, response) => {
     const vendas = await listVendas(request.query);
 
@@ -32,6 +41,7 @@ vendasRoutes.get(
 
 vendasRoutes.get(
   "/:id",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
   asyncHandler(async (request, response) => {
     const venda = await getVendaById(request.params.id);
 
@@ -41,6 +51,7 @@ vendasRoutes.get(
 
 vendasRoutes.patch(
   "/:id/cancelar",
+  ensureRole("PROPRIETARIO"),
   asyncHandler(async (request, response) => {
     const venda = await cancelarVenda(request.params.id);
 
@@ -50,6 +61,7 @@ vendasRoutes.patch(
 
 vendasRoutes.put(
   "/:id",
+  ensureRole("PROPRIETARIO"),
   asyncHandler(async (request, response) => {
     const venda = await updateVenda(request.params.id, request.body);
 
@@ -59,6 +71,7 @@ vendasRoutes.put(
 
 vendasRoutes.delete(
   "/:id",
+  ensureRole("PROPRIETARIO"),
   asyncHandler(async (request, response) => {
     await deleteVenda(request.params.id);
 

--- a/apps/api/src/services/authService.js
+++ b/apps/api/src/services/authService.js
@@ -1,0 +1,83 @@
+import { prisma } from "../config/prisma.js";
+import { isSupabaseAdminUser } from "../config/auth.js";
+import { requestPasswordRecovery, signInWithPassword, updateSupabasePassword } from "./supabaseAuthService.js";
+import { AppError } from "../utils/AppError.js";
+import { validateStrongPassword } from "../utils/password.js";
+
+export async function loginFuncionario({ email, senha }) {
+  if (!email || !senha) {
+    throw new AppError("E-mail e senha sao obrigatorios.", 400);
+  }
+
+  const session = await signInWithPassword(email, senha);
+  const funcionario = await prisma.funcionario.findFirst({
+    where: {
+      email,
+      ativo: true,
+    },
+    select: {
+      id: true,
+      nome: true,
+      email: true,
+      role: true,
+      cargo: true,
+    },
+  });
+
+  if (!funcionario && isSupabaseAdminUser(session.user?.id)) {
+    return {
+      token: session.access_token,
+      refreshToken: session.refresh_token,
+      expiresIn: session.expires_in,
+      usuario: {
+        id: null,
+        nome: session.user.email,
+        email: session.user.email,
+        role: "PROPRIETARIO",
+        cargo: "Administrador",
+        supabaseUserId: session.user.id,
+      },
+    };
+  }
+
+  if (!funcionario) {
+    throw new AppError("Funcionario autenticado nao encontrado no sistema.", 401);
+  }
+
+  return {
+    token: session.access_token,
+    refreshToken: session.refresh_token,
+    expiresIn: session.expires_in,
+    usuario: {
+      ...funcionario,
+      role: isSupabaseAdminUser(session.user?.id) ? "PROPRIETARIO" : funcionario.role,
+      supabaseUserId: session.user?.id,
+    },
+  };
+}
+
+export async function solicitarRedefinicaoSenha({ email, redirectTo }) {
+  if (!email) {
+    throw new AppError("E-mail e obrigatorio.", 400);
+  }
+
+  await requestPasswordRecovery(email, redirectTo);
+
+  return {
+    message: "Se o e-mail existir no Supabase Auth, as instrucoes de redefinicao serao enviadas.",
+  };
+}
+
+export async function atualizarSenhaUsuario({ token, senha }) {
+  if (!token || !senha) {
+    throw new AppError("Token e nova senha sao obrigatorios.", 400);
+  }
+
+  validateStrongPassword(senha, "nova senha");
+
+  await updateSupabasePassword(token, senha);
+
+  return {
+    message: "Senha atualizada com sucesso.",
+  };
+}

--- a/apps/api/src/services/funcionarioService.js
+++ b/apps/api/src/services/funcionarioService.js
@@ -2,7 +2,9 @@ import bcrypt from "bcryptjs";
 
 import { prisma } from "../config/prisma.js";
 import { Role } from "../domain/enums.js";
+import { createSupabaseUser } from "./supabaseAuthService.js";
 import { AppError } from "../utils/AppError.js";
+import { validateStrongPassword } from "../utils/password.js";
 import { ensureEnumValue, parseId, requireFields } from "../utils/validation.js";
 
 const funcionarioInclude = {
@@ -69,6 +71,7 @@ async function buildFuncionarioData(data, { partial = false } = {}) {
   }
 
   if (data.senha) {
+    validateStrongPassword(data.senha);
     funcionarioData.senhaHash = await bcrypt.hash(data.senha, 10);
   }
 
@@ -76,6 +79,18 @@ async function buildFuncionarioData(data, { partial = false } = {}) {
 }
 
 export async function createFuncionario(data) {
+  validateStrongPassword(data.senha);
+
+  await createSupabaseUser({
+    email: data.email,
+    password: data.senha,
+    metadata: {
+      nome: data.nome,
+      role: data.role,
+      cargo: data.cargo,
+    },
+  });
+
   const funcionario = await prisma.funcionario.create({
     data: await buildFuncionarioData(data),
     include: funcionarioInclude,

--- a/apps/api/src/services/supabaseAuthService.js
+++ b/apps/api/src/services/supabaseAuthService.js
@@ -1,0 +1,114 @@
+import { AppError } from "../utils/AppError.js";
+
+const supabaseUrl = process.env.SUPABASE_PROJECT_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+function ensureSupabaseAuthConfig({ admin = false } = {}) {
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new AppError("Autenticacao Supabase nao configurada.", 500);
+  }
+
+  if (admin && !supabaseServiceRoleKey) {
+    throw new AppError("Chave service role do Supabase nao configurada.", 500);
+  }
+}
+
+async function parseSupabaseResponse(response, fallbackMessage) {
+  const body = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    throw new AppError(body?.error_description ?? body?.msg ?? body?.message ?? fallbackMessage, response.status);
+  }
+
+  return body;
+}
+
+export async function signInWithPassword(email, password) {
+  ensureSupabaseAuthConfig();
+
+  const response = await fetch(`${supabaseUrl}/auth/v1/token?grant_type=password`, {
+    method: "POST",
+    headers: {
+      apikey: supabaseAnonKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email,
+      password,
+    }),
+  });
+
+  return parseSupabaseResponse(response, "Credenciais invalidas no Supabase Auth.");
+}
+
+export async function getSupabaseUser(accessToken) {
+  ensureSupabaseAuthConfig();
+
+  const response = await fetch(`${supabaseUrl}/auth/v1/user`, {
+    headers: {
+      apikey: supabaseAnonKey,
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  return parseSupabaseResponse(response, "Token Supabase invalido.");
+}
+
+export async function createSupabaseUser({ email, password, metadata = {} }) {
+  ensureSupabaseAuthConfig({ admin: true });
+
+  const response = await fetch(`${supabaseUrl}/auth/v1/admin/users`, {
+    method: "POST",
+    headers: {
+      apikey: supabaseServiceRoleKey,
+      Authorization: `Bearer ${supabaseServiceRoleKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email,
+      password,
+      email_confirm: true,
+      user_metadata: metadata,
+    }),
+  });
+
+  return parseSupabaseResponse(response, "Nao foi possivel criar usuario no Supabase Auth.");
+}
+
+export async function requestPasswordRecovery(email, redirectTo) {
+  ensureSupabaseAuthConfig();
+
+  const response = await fetch(`${supabaseUrl}/auth/v1/recover`, {
+    method: "POST",
+    headers: {
+      apikey: supabaseAnonKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email,
+      gotrue_meta_security: {},
+      ...(redirectTo ? { redirect_to: redirectTo } : {}),
+    }),
+  });
+
+  return parseSupabaseResponse(response, "Nao foi possivel solicitar redefinicao de senha.");
+}
+
+export async function updateSupabasePassword(accessToken, password) {
+  ensureSupabaseAuthConfig();
+
+  const response = await fetch(`${supabaseUrl}/auth/v1/user`, {
+    method: "PUT",
+    headers: {
+      apikey: supabaseAnonKey,
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      password,
+    }),
+  });
+
+  return parseSupabaseResponse(response, "Nao foi possivel atualizar a senha.");
+}

--- a/apps/api/src/utils/password.js
+++ b/apps/api/src/utils/password.js
@@ -1,0 +1,12 @@
+import { AppError } from "./AppError.js";
+
+const STRONG_PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{10,}$/;
+
+export function validateStrongPassword(password, fieldName = "senha") {
+  if (typeof password !== "string" || !STRONG_PASSWORD_REGEX.test(password)) {
+    throw new AppError(
+      `O campo ${fieldName} deve ter pelo menos 10 caracteres, com maiuscula, minuscula, numero e caractere especial.`,
+      400,
+    );
+  }
+}

--- a/apps/web/src/app/app.config.ts
+++ b/apps/web/src/app/app.config.ts
@@ -1,14 +1,15 @@
 import { ApplicationConfig, LOCALE_ID, provideBrowserGlobalErrorListeners } from "@angular/core";
-import { provideHttpClient } from "@angular/common/http";
+import { provideHttpClient, withInterceptors } from "@angular/common/http";
 import { provideAnimationsAsync } from "@angular/platform-browser/animations/async";
 import { provideRouter } from "@angular/router";
 import { routes } from "./app.routes";
+import { authInterceptor } from "./core/interceptors/auth.interceptor";
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideAnimationsAsync(),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([authInterceptor])),
     provideRouter(routes),
     { provide: LOCALE_ID, useValue: "pt-BR" }
   ]

--- a/apps/web/src/app/core/interceptors/auth.interceptor.ts
+++ b/apps/web/src/app/core/interceptors/auth.interceptor.ts
@@ -1,0 +1,18 @@
+import { HttpInterceptorFn } from "@angular/common/http";
+import { inject } from "@angular/core";
+import { AuthService } from "../services/auth.service";
+
+export const authInterceptor: HttpInterceptorFn = (request, next) => {
+  const authService = inject(AuthService);
+  const token = authService.getToken();
+
+  if (!token) {
+    return next(request);
+  }
+
+  return next(request.clone({
+    setHeaders: {
+      Authorization: `Bearer ${token}`,
+    },
+  }));
+};

--- a/apps/web/src/app/core/models.ts
+++ b/apps/web/src/app/core/models.ts
@@ -99,7 +99,7 @@ export interface CreateSaleItemPayload {
 }
 
 export interface CreateSalePayload {
-  funcionarioId: number;
+  funcionarioId?: number;
   clienteId?: number | null;
   formaPagamento: string;
   status?: string;

--- a/apps/web/src/app/core/services/auth.service.ts
+++ b/apps/web/src/app/core/services/auth.service.ts
@@ -1,27 +1,86 @@
-import { Injectable } from "@angular/core";
-import { LOGIN_EMAIL, LOGIN_PASSWORD } from "../mock-data";
+import { Injectable, inject } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable, tap } from "rxjs";
 
-const AUTH_KEY = "pao-fresquim-auth";
+const API_BASE_URL = "http://localhost:3333";
+const TOKEN_KEY = "pao-fresquim-auth-token";
+const REFRESH_TOKEN_KEY = "pao-fresquim-auth-refresh-token";
+const USER_KEY = "pao-fresquim-auth-user";
+
+export type AuthUser = {
+  id: number | null;
+  nome: string;
+  email: string;
+  role: "PROPRIETARIO" | "ATENDENTE" | "PADEIRO";
+  cargo: string;
+  supabaseUserId?: string;
+};
+
+export type LoginResponse = {
+  token: string;
+  refreshToken?: string;
+  expiresIn?: number;
+  usuario: AuthUser;
+};
 
 @Injectable({ providedIn: "root" })
 export class AuthService {
+  private readonly http = inject(HttpClient);
+
   isAuthenticated(): boolean {
-    return localStorage.getItem(AUTH_KEY) === "true";
+    return Boolean(this.getToken());
   }
 
-  login(email: string, password: string): boolean {
-    const valid =
-      email.trim().toLowerCase() === LOGIN_EMAIL &&
-      password.trim() === LOGIN_PASSWORD;
+  login(email: string, senha: string): Observable<LoginResponse> {
+    return this.http
+      .post<LoginResponse>(`${API_BASE_URL}/api/auth/login`, { email, senha })
+      .pipe(tap((response) => this.persistSession(response)));
+  }
 
-    if (valid) {
-      localStorage.setItem(AUTH_KEY, "true");
+  requestPasswordReset(email: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(`${API_BASE_URL}/api/auth/password/recover`, {
+      email,
+      redirectTo: `${window.location.origin}/login`,
+    });
+  }
+
+  updatePassword(token: string, senha: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(`${API_BASE_URL}/api/auth/password/update`, {
+      token,
+      senha,
+    });
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem(TOKEN_KEY);
+  }
+
+  getUser(): AuthUser | null {
+    const rawUser = localStorage.getItem(USER_KEY);
+
+    if (!rawUser) {
+      return null;
     }
 
-    return valid;
+    try {
+      return JSON.parse(rawUser) as AuthUser;
+    } catch {
+      return null;
+    }
   }
 
   logout(): void {
-    localStorage.removeItem(AUTH_KEY);
+    localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+    localStorage.removeItem(USER_KEY);
+  }
+
+  private persistSession(response: LoginResponse): void {
+    localStorage.setItem(TOKEN_KEY, response.token);
+    localStorage.setItem(USER_KEY, JSON.stringify(response.usuario));
+
+    if (response.refreshToken) {
+      localStorage.setItem(REFRESH_TOKEN_KEY, response.refreshToken);
+    }
   }
 }

--- a/apps/web/src/app/features/cameras/cameras.component.css
+++ b/apps/web/src/app/features/cameras/cameras.component.css
@@ -31,6 +31,54 @@
   letter-spacing: 0.08em;
 }
 
+.camera-video {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  background: #0f172a;
+}
+
+.camera-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.08), rgba(15, 23, 42, 0.62)),
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.05) 0,
+      rgba(255, 255, 255, 0.05) 1px,
+      transparent 1px,
+      transparent 5px
+    );
+}
+
+.camera-frozen .camera-overlay {
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.12), rgba(15, 23, 42, 0.76)),
+    repeating-linear-gradient(
+      0deg,
+      rgba(255, 255, 255, 0.08) 0,
+      rgba(255, 255, 255, 0.08) 1px,
+      transparent 1px,
+      transparent 4px
+    );
+}
+
+.camera-freeze-label {
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  padding: 0.45rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(248, 113, 113, 0.92);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
 .camera-badge {
   position: absolute;
   left: 1rem;
@@ -48,12 +96,34 @@
   height: 10px;
   border-radius: 999px;
   background: #22c55e;
+  box-shadow: 0 0 0 6px rgba(34, 197, 94, 0.18);
 }
 
 .cam-stat,
 .camera-side {
   display: grid;
   gap: 1rem;
+}
+
+.cam-info {
+  position: absolute;
+  left: 1rem;
+  bottom: 1rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.68);
+  backdrop-filter: blur(10px);
+}
+
+.cam-title {
+  font-weight: 800;
+}
+
+.cam-code {
+  margin-top: 0.15rem;
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.72);
+  letter-spacing: 0.08em;
 }
 
 .cam-stat {

--- a/apps/web/src/app/features/cameras/cameras.component.html
+++ b/apps/web/src/app/features/cameras/cameras.component.html
@@ -4,22 +4,53 @@
     <div class="page-subtitle">Centro de operacoes de seguranca em tempo real.</div>
   </div>
   <div class="toolbar">
-    <button class="btn-secondary" type="button">Parar todos</button>
-    <button class="btn-primary" type="button">Tentar reconectar</button>
+    <button class="btn-secondary" type="button" (click)="freezeAll()">
+      {{ isFrozen ? "Feeds congelados" : "Parar todos" }}
+    </button>
+    <button class="btn-primary" type="button" (click)="reconnectAll()">Tentar reconectar</button>
   </div>
 </div>
 
 <div class="cameras-grid">
-  <div class="camera-main">
-    <div class="camera-feed">CAMERA LOJA</div>
-    <div class="camera-badge"><span class="cam-live-dot"></span> Camera loja | online</div>
+  <div class="camera-main" [class.camera-frozen]="isFrozen">
+    <video
+      #cameraVideo
+      class="camera-video"
+      autoplay
+      loop
+      muted
+      playsinline
+      preload="metadata"
+      [attr.aria-label]="cameraFeeds[0].title"
+      [muted]="true"
+    >
+      <source [src]="cameraFeeds[0].url" type="video/mp4" />
+    </video>
+    <div class="camera-overlay"></div>
+    <div *ngIf="isFrozen" class="camera-freeze-label">FRAME CONGELADO</div>
+    <div class="camera-badge"><span class="cam-live-dot"></span> {{ cameraFeeds[0].title }} | {{ cameraFeeds[0].status }}</div>
   </div>
 
   <div class="camera-side">
-    <div class="camera-second">
-      <div class="camera-feed-sm">COZINHA</div>
+    <div class="camera-second" *ngFor="let feed of sideCameraFeeds" [class.camera-frozen]="isFrozen">
+      <video
+        #cameraVideo
+        class="camera-video"
+        autoplay
+        loop
+        muted
+        playsinline
+        preload="metadata"
+        [attr.aria-label]="feed.title"
+        [muted]="true"
+      >
+        <source [src]="feed.url" type="video/mp4" />
+      </video>
+      <div class="camera-overlay"></div>
+      <div *ngIf="isFrozen" class="camera-freeze-label">FRAME CONGELADO</div>
       <div class="cam-info">
-        <div class="cam-title">Camera cozinha</div>
+        <div class="cam-title">{{ feed.title }}</div>
+        <div class="cam-code">{{ feed.label }}</div>
       </div>
     </div>
 

--- a/apps/web/src/app/features/cameras/cameras.component.ts
+++ b/apps/web/src/app/features/cameras/cameras.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { Component, ElementRef, QueryList, ViewChildren } from "@angular/core";
 import { cameras, logs } from "../../core/mock-data";
 
 @Component({
@@ -10,6 +10,48 @@ import { cameras, logs } from "../../core/mock-data";
   styleUrl: "./cameras.component.css"
 })
 export class CamerasComponent {
+  @ViewChildren("cameraVideo") private readonly cameraVideos?: QueryList<ElementRef<HTMLVideoElement>>;
+
+  isFrozen = false;
+
+  readonly cameraFeeds = [
+    {
+      title: "Camera loja",
+      label: "CAM_02_CHECKOUT",
+      status: "online",
+      url: "https://jzryonfvdsmnkzkiclpj.supabase.co/storage/v1/object/public/videos/cameras/loja.mp4",
+    },
+    {
+      title: "Camera cozinha",
+      label: "CAM_04_KITCHEN",
+      status: "online",
+      url: "https://jzryonfvdsmnkzkiclpj.supabase.co/storage/v1/object/public/videos/cameras/cozinha.mp4",
+    },
+    {
+      title: "Camera producao",
+      label: "CAM_06_PRODUCAO",
+      status: "online",
+      url: "https://jzryonfvdsmnkzkiclpj.supabase.co/storage/v1/object/public/videos/cameras/producao.mp4",
+    },
+  ];
+  readonly sideCameraFeeds = this.cameraFeeds.slice(1);
   readonly cameras = cameras;
   readonly logs = logs;
+
+  freezeAll(): void {
+    this.isFrozen = true;
+    this.forEachVideo((video) => video.pause());
+  }
+
+  reconnectAll(): void {
+    this.isFrozen = false;
+    this.forEachVideo((video) => {
+      video.load();
+      void video.play();
+    });
+  }
+
+  private forEachVideo(callback: (video: HTMLVideoElement) => void): void {
+    this.cameraVideos?.forEach((videoRef) => callback(videoRef.nativeElement));
+  }
 }

--- a/apps/web/src/app/features/employees/employees.component.html
+++ b/apps/web/src/app/features/employees/employees.component.html
@@ -168,7 +168,14 @@
 
           <div class="form-group employee-form-full">
             <label class="form-label">Senha {{ modalMode === 'edit' ? '(preencha somente para trocar)' : '' }}</label>
-            <input class="form-input" name="senha" type="password" [(ngModel)]="form.senha" [required]="modalMode === 'create'" />
+            <input
+              class="form-input"
+              name="senha"
+              type="password"
+              [(ngModel)]="form.senha"
+              placeholder="Minimo 10, Aa, numero e especial"
+              [required]="modalMode === 'create'"
+            />
           </div>
         </div>
 

--- a/apps/web/src/app/features/employees/employees.component.ts
+++ b/apps/web/src/app/features/employees/employees.component.ts
@@ -136,6 +136,11 @@ export class EmployeesComponent implements OnInit {
       return;
     }
 
+    if (this.form.senha.trim() && !this.isStrongPassword(this.form.senha.trim())) {
+      this.showPersistenceError("A senha deve ter minimo 10 caracteres, maiuscula, minuscula, numero e especial.");
+      return;
+    }
+
     const payload = this.toPayload();
 
     if (this.modalMode === "edit" && this.form.id !== null) {
@@ -263,6 +268,10 @@ export class EmployeesComponent implements OnInit {
     ];
 
     return requiredValues.every((value) => value.trim().length > 0) && (this.modalMode === "edit" || this.form.senha.trim().length > 0);
+  }
+
+  private isStrongPassword(password: string): boolean {
+    return /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{10,}$/.test(password);
   }
 
   private toDateInput(date?: string): string {

--- a/apps/web/src/app/features/login/login.component.css
+++ b/apps/web/src/app/features/login/login.component.css
@@ -79,6 +79,22 @@
   padding: 0.85rem 1rem;
 }
 
+.secondary-login-action {
+  margin-top: 0.7rem;
+  background: #eef3f8;
+  color: #17233a;
+}
+
+.success-box {
+  margin-top: 1rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 10px;
+  background: #ecfdf5;
+  color: #047857;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
 .error-box {
   padding: 0.85rem 1rem;
   border-radius: 12px;

--- a/apps/web/src/app/features/login/login.component.html
+++ b/apps/web/src/app/features/login/login.component.html
@@ -7,18 +7,19 @@
     </div>
 
     <div class="login-credentials">
-      <strong>{{ loginEmail }}</strong>
-      <strong>{{ loginPassword }}</strong>
+      <strong>Supabase Auth</strong>
+      <span>Use o e-mail do funcionario cadastrado.</span>
     </div>
 
+    <ng-container *ngIf="!isResetMode; else resetPasswordForm">
     <div class="login-field">
       <label class="login-label" for="email">Usuario</label>
-      <input class="login-input" id="email" name="email" type="email" [(ngModel)]="email" placeholder="arthur@email.com" />
+      <input class="login-input" id="email" name="email" type="email" [(ngModel)]="email" placeholder="joaquim@paofresquim.com" />
     </div>
 
     <div class="login-field">
       <label class="login-label" for="password">Senha</label>
-      <input class="login-input" id="password" name="password" type="password" [(ngModel)]="password" placeholder="1234" />
+      <input class="login-input" id="password" name="password" type="password" [(ngModel)]="password" placeholder="Senha do Supabase Auth" />
     </div>
 
     <div class="login-row">
@@ -29,11 +30,26 @@
       <span class="login-forgot">Esqueceu a senha?</span>
     </div>
 
-    <button class="btn-login" type="submit">Entrar no sistema</button>
+    <button class="btn-login" type="submit" [disabled]="isSubmitting">{{ isSubmitting ? "Entrando..." : "Entrar no sistema" }}</button>
+    <button class="btn-login secondary-login-action" type="button" [disabled]="isSubmitting" (click)="requestPasswordReset()">Redefinir senha</button>
     <div *ngIf="error" class="error-box">{{ error }}</div>
+    <div *ngIf="success" class="success-box">{{ success }}</div>
+    </ng-container>
+
+    <ng-template #resetPasswordForm>
+      <div class="login-field">
+        <label class="login-label" for="newPassword">Nova senha</label>
+        <input class="login-input" id="newPassword" name="newPassword" type="password" [(ngModel)]="newPassword" placeholder="Minimo 10, Aa, numero e especial" />
+      </div>
+      <button class="btn-login" type="button" [disabled]="isSubmitting" (click)="updatePassword()">
+        {{ isSubmitting ? "Atualizando..." : "Salvar nova senha" }}
+      </button>
+      <div *ngIf="error" class="error-box">{{ error }}</div>
+      <div *ngIf="success" class="success-box">{{ success }}</div>
+    </ng-template>
 
     <div class="login-support">
-      Total vendido hoje: <strong>{{ totalSoldToday }}</strong>
+      Login validado pelo Supabase Auth e vinculado ao cadastro de funcionario.
     </div>
     <div class="login-security">
       <span>Problemas com o acesso?</span>

--- a/apps/web/src/app/features/login/login.component.ts
+++ b/apps/web/src/app/features/login/login.component.ts
@@ -2,9 +2,7 @@ import { CommonModule } from "@angular/common";
 import { Component, inject } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { Router } from "@angular/router";
-import { LOGIN_EMAIL, LOGIN_PASSWORD, overview } from "../../core/mock-data";
 import { AuthService } from "../../core/services/auth.service";
-import { formatCurrency } from "../../core/utils/format";
 
 @Component({
   selector: "pf-login",
@@ -19,23 +17,99 @@ export class LoginComponent {
 
   email = "";
   password = "";
+  newPassword = "";
   error = "";
-  readonly loginEmail = LOGIN_EMAIL;
-  readonly loginPassword = LOGIN_PASSWORD;
-  readonly totalSoldToday = formatCurrency(overview.totalSoldToday);
+  success = "";
+  isSubmitting = false;
+  isResetMode = false;
+  recoveryToken = "";
 
   constructor() {
+    this.recoveryToken = this.getRecoveryTokenFromUrl();
+    this.isResetMode = Boolean(this.recoveryToken);
+
     if (this.authService.isAuthenticated()) {
       this.router.navigateByUrl("/dashboard");
     }
   }
 
   submit(): void {
-    if (this.authService.login(this.email, this.password)) {
-      this.router.navigateByUrl("/dashboard");
+    if (!this.email.trim() || !this.password.trim()) {
+      this.error = "Informe e-mail e senha.";
       return;
     }
 
-    this.error = "Credenciais invalidas. Use arthur@email.com e 1234.";
+    this.isSubmitting = true;
+    this.error = "";
+    this.success = "";
+
+    this.authService.login(this.email.trim(), this.password).subscribe({
+      next: () => {
+        this.isSubmitting = false;
+        this.router.navigateByUrl("/dashboard");
+      },
+      error: () => {
+        this.isSubmitting = false;
+        this.error = "Credenciais invalidas ou usuario sem funcionario ativo vinculado.";
+      },
+    });
+  }
+
+  requestPasswordReset(): void {
+    if (!this.email.trim()) {
+      this.error = "Informe o e-mail para redefinir a senha.";
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.error = "";
+    this.success = "";
+
+    this.authService.requestPasswordReset(this.email.trim()).subscribe({
+      next: (response) => {
+        this.isSubmitting = false;
+        this.success = response.message;
+      },
+      error: () => {
+        this.isSubmitting = false;
+        this.error = "Nao foi possivel solicitar redefinicao de senha.";
+      },
+    });
+  }
+
+  updatePassword(): void {
+    if (!this.recoveryToken || !this.isStrongPassword(this.newPassword)) {
+      this.error = "Use uma senha com minimo 10 caracteres, maiuscula, minuscula, numero e especial.";
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.error = "";
+    this.success = "";
+
+    this.authService.updatePassword(this.recoveryToken, this.newPassword).subscribe({
+      next: () => {
+        this.isSubmitting = false;
+        this.success = "Senha atualizada. Faca login com a nova senha.";
+        this.isResetMode = false;
+        this.recoveryToken = "";
+        this.newPassword = "";
+      },
+      error: () => {
+        this.isSubmitting = false;
+        this.error = "Nao foi possivel atualizar a senha. Solicite um novo link.";
+      },
+    });
+  }
+
+  private getRecoveryTokenFromUrl(): string {
+    const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+    const queryParams = new URLSearchParams(window.location.search);
+
+    return hashParams.get("access_token") ?? queryParams.get("access_token") ?? "";
+  }
+
+  private isStrongPassword(password: string): boolean {
+    return /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{10,}$/.test(password);
   }
 }

--- a/apps/web/src/app/features/sale/sale.component.html
+++ b/apps/web/src/app/features/sale/sale.component.html
@@ -96,7 +96,7 @@
     <div class="payment-panel sale-contract-note">
       <div class="payment-label">Status da integracao</div>
       <div class="client-time">
-        Clientes, produtos e fechamento de venda usam API. O operador ainda usa `funcionarioId` fixo ate a autenticacao retornar o funcionario logado.
+        Clientes, produtos e fechamento de venda usam API. O operador e identificado pelo token Supabase Auth no backend.
       </div>
     </div>
 

--- a/apps/web/src/app/features/sale/sale.component.ts
+++ b/apps/web/src/app/features/sale/sale.component.ts
@@ -94,7 +94,6 @@ export class SaleComponent implements OnInit {
     this.errorMessage = "";
 
     this.salesApiService.createSale({
-      funcionarioId: 1,
       clienteId: this.selectedClientId ? Number(this.selectedClientId) : null,
       formaPagamento: this.toFormaPagamento(this.payment),
       status: "CONCLUIDA",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "prisma:db:push": "npm run prisma:db:push --workspace @padaria/api",
     "prisma:studio": "npm run prisma:studio --workspace @padaria/api",
     "prisma:seed": "npm run prisma:seed --workspace @padaria/api",
-    "storage:setup": "npm run storage:setup --workspace @padaria/api"
+    "storage:setup": "npm run storage:setup --workspace @padaria/api",
+    "auth:seed": "npm run auth:seed --workspace @padaria/api"
   },
   "workspaces": [
     "apps/*"


### PR DESCRIPTION
## Resumo
Integra o login do sistema ao Supabase Auth, aplica controle de acesso por role nas rotas principais da API e adiciona feeds de camera em video na tela de monitoramento.

## O que entra
- Endpoints `/api/auth/login`, `/api/auth/me`, `/api/auth/password/recover` e `/api/auth/password/update`.
- Middleware `ensureAuth` com token Bearer do Supabase e permissao por role (`PROPRIETARIO`, `ATENDENTE`, `PADEIRO`).
- Allowlist de UUIDs administrativos via `SUPABASE_ADMIN_USER_IDS` para usuarios criados direto no Supabase.
- Interceptor Angular enviando `Authorization: Bearer <token>` nas chamadas da API.
- Tela de login consumindo a API real e fluxo inicial de redefinicao de senha.
- Cadastro/edicao de funcionarios criando usuario no Supabase Auth e mantendo `senhaHash` somente no banco local.
- Politica de senha forte: minimo 10 caracteres, letra maiuscula, minuscula, numero e caractere especial.
- Script `npm run auth:seed` para criar usuarios Auth dos funcionarios ativos.
- Tela de Cameras usando videos MP4 do Supabase Storage em `autoplay`, `loop`, `muted` e `playsinline`.
- Botao `Parar todos` congela os feeds no frame atual; `Tentar reconectar` recarrega os videos.

## Observacoes
- `.env` real fica local e nao entra no commit; `.env.example` tem apenas placeholders.
- Usuarios Auth criados antes desta regra ainda precisam trocar senha pelo fluxo de redefinicao ou pelo painel do Supabase.
- Usuario administrativo sem funcionario vinculado consegue acessar rotas administrativas, mas criar venda exige funcionario vinculado para registrar `funcionarioId` corretamente.
- Os videos foram enviados ao bucket publico `videos` no Supabase Storage.

## Validacao
- `npm run build:web`
- `npm run prisma:validate`
- `node --check` nos arquivos backend alterados
- HEAD dos videos publicos retornando `200 video/mp4`