### PR TITLE
feat: chatbot Evolution, configuracoes e funcionarios (ponto/documentos)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 coverage/
 apps/api/src/generated/
 apps/api/.runtime/
+!apps/api/.runtime/.gitkeep
 apps/web/.angular/
 *.log
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 .turbo/
 coverage/
 apps/api/src/generated/
+apps/api/.runtime/
 apps/web/.angular/
 *.log
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -33,3 +33,6 @@ SUPABASE_STORAGE_BUCKET_PRODUTOS="produtos"
 SUPABASE_AUTH_SEED_PASSWORD="[STRONG-TEMP-PASSWORD]"
 # UUIDs do Supabase Auth que devem receber acesso administrativo mesmo se criados direto no painel.
 SUPABASE_ADMIN_USER_IDS=""
+
+# Chatbot/Evolution: URL, API key, token do webhook, funcionario operador e WhatsApp do proprietario
+# sao cadastrados no painel Configuracoes do front e persistidos em .runtime/chatbot-config.json.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -28,6 +28,8 @@ SUPABASE_ANON_KEY="[YOUR-ANON-KEY]"
 SUPABASE_SERVICE_ROLE_KEY="[YOUR-SERVICE-ROLE-KEY]"
 # Nome do bucket público reservado para imagens de produtos.
 SUPABASE_STORAGE_BUCKET_PRODUTOS="produtos"
+# Bucket para PDFs de funcionarios (atestados, contratos, etc.). Se vazio, usa fallback local em .runtime/documentos.
+SUPABASE_STORAGE_BUCKET_FUNCIONARIOS="funcionarios-documentos"
 # Senha temporaria forte usada para criar usuarios Auth a partir dos funcionarios seedados.
 # Troque em cada ambiente antes de rodar o seed.
 SUPABASE_AUTH_SEED_PASSWORD="[STRONG-TEMP-PASSWORD]"

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,8 @@
     "prisma:seed": "node prisma/seed.js",
     "storage:setup": "node scripts/setup-storage-produtos.js",
     "auth:seed": "node scripts/seed-auth-users.js",
-    "ponto:seed": "node scripts/seed-ponto-historico.js"
+    "ponto:seed": "node scripts/seed-ponto-historico.js",
+    "documentos:cleanup-teste": "node scripts/cleanup-documentos-teste.js"
   },
   "devDependencies": {
     "nodemon": "^3.1.14",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,7 +14,8 @@
     "prisma:validate": "prisma validate",
     "prisma:seed": "node prisma/seed.js",
     "storage:setup": "node scripts/setup-storage-produtos.js",
-    "auth:seed": "node scripts/seed-auth-users.js"
+    "auth:seed": "node scripts/seed-auth-users.js",
+    "ponto:seed": "node scripts/seed-ponto-historico.js"
   },
   "devDependencies": {
     "nodemon": "^3.1.14",

--- a/apps/api/scripts/cleanup-documentos-teste.js
+++ b/apps/api/scripts/cleanup-documentos-teste.js
@@ -1,0 +1,28 @@
+// apps/api/scripts/cleanup-documentos-teste.js
+// Removes demonstration/test employee documents from the database.
+import "dotenv/config";
+
+import { prisma } from "../src/config/prisma.js";
+
+async function main() {
+  const deleted = await prisma.atestado.deleteMany({
+    where: {
+      OR: [
+        { arquivoUrl: { contains: "example.com" } },
+        { observacao: { contains: "fake", mode: "insensitive" } },
+        { observacao: { contains: "demonstracao", mode: "insensitive" } },
+        { observacao: { equals: "Teste", mode: "insensitive" } },
+      ],
+    },
+  });
+
+  console.log(JSON.stringify({ documentosRemovidos: deleted.count }, null, 2));
+}
+
+main()
+  .then(async () => prisma.$disconnect())
+  .catch(async (error) => {
+    console.error(error);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/apps/api/scripts/seed-ponto-historico.js
+++ b/apps/api/scripts/seed-ponto-historico.js
@@ -1,0 +1,135 @@
+// apps/api/scripts/seed-ponto-historico.js
+// Generates historical clock-in records for active employees (01/05 to 18/05).
+import "dotenv/config";
+
+import { prisma } from "../src/config/prisma.js";
+
+const PERIOD_START = { year: 2026, month: 5, day: 1 };
+const PERIOD_END = { year: 2026, month: 5, day: 18 };
+
+const SHIFT_BY_ROLE = {
+  PADEIRO: { entrada: [5, 30], saida: [14, 0] },
+  ATENDENTE: { entrada: [8, 0], saida: [17, 30] },
+  PROPRIETARIO: { entrada: [7, 0], saida: [18, 0] },
+};
+
+function buildDate({ year, month, day }, [hour, minute]) {
+  return new Date(year, month - 1, day, hour, minute, 0, 0);
+}
+
+function eachDayInclusive(start, end) {
+  const days = [];
+  const cursor = new Date(start.year, start.month - 1, start.day);
+  const last = new Date(end.year, end.month - 1, end.day);
+
+  while (cursor <= last) {
+    days.push({
+      year: cursor.getFullYear(),
+      month: cursor.getMonth() + 1,
+      day: cursor.getDate(),
+      weekday: cursor.getDay(),
+    });
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return days;
+}
+
+function jitterMinutes(baseHour, baseMinute, spread = 12) {
+  const offset = Math.floor(Math.random() * (spread * 2 + 1)) - spread;
+  const total = baseHour * 60 + baseMinute + offset;
+  const hour = Math.floor(total / 60);
+  const minute = total % 60;
+  return [hour, minute];
+}
+
+function resolveShift(role, funcionarioId, dayIndex) {
+  if (role === "ATENDENTE" && funcionarioId % 2 === 0) {
+    return { entrada: [12, 0], saida: [20, 20] };
+  }
+
+  return SHIFT_BY_ROLE[role] ?? SHIFT_BY_ROLE.ATENDENTE;
+}
+
+async function main() {
+  const funcionarios = await prisma.funcionario.findMany({
+    where: { ativo: true },
+    select: { id: true, nome: true, role: true },
+    orderBy: { id: "asc" },
+  });
+
+  if (funcionarios.length === 0) {
+    throw new Error("Nenhum funcionario ativo encontrado para gerar ponto.");
+  }
+
+  const rangeStart = buildDate(PERIOD_START, [0, 0]);
+  const rangeEnd = buildDate(PERIOD_END, [23, 59]);
+  const funcionarioIds = funcionarios.map((item) => item.id);
+
+  const deleted = await prisma.registroPonto.deleteMany({
+    where: {
+      funcionarioId: { in: funcionarioIds },
+      dataHoraBatida: {
+        gte: rangeStart,
+        lte: rangeEnd,
+      },
+    },
+  });
+
+  const days = eachDayInclusive(PERIOD_START, PERIOD_END).filter((day) => day.weekday !== 0);
+  const records = [];
+
+  for (const funcionario of funcionarios) {
+    days.forEach((day, dayIndex) => {
+      const shift = resolveShift(funcionario.role, funcionario.id, dayIndex);
+      const [entradaHour, entradaMinute] = jitterMinutes(shift.entrada[0], shift.entrada[1]);
+      const [saidaHour, saidaMinute] = jitterMinutes(shift.saida[0], shift.saida[1], 8);
+
+      records.push(
+        {
+          funcionarioId: funcionario.id,
+          tipoRegistro: "ENTRADA",
+          dataHoraBatida: buildDate(day, [entradaHour, entradaMinute]),
+        },
+        {
+          funcionarioId: funcionario.id,
+          tipoRegistro: "SAIDA",
+          dataHoraBatida: buildDate(day, [saidaHour, saidaMinute]),
+        },
+      );
+    });
+  }
+
+  const batchSize = 250;
+  let created = 0;
+
+  for (let index = 0; index < records.length; index += batchSize) {
+    const chunk = records.slice(index, index + batchSize);
+    const result = await prisma.registroPonto.createMany({ data: chunk });
+    created += result.count;
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        funcionarios: funcionarios.length,
+        diasUteis: days.length,
+        removidosNoPeriodo: deleted.count,
+        registrosCriados: created,
+        periodo: "01/05/2026 a 18/05/2026",
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (error) => {
+    console.error("Erro ao gerar ponto historico:", error);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/apps/api/src/middlewares/evolutionWebhook.js
+++ b/apps/api/src/middlewares/evolutionWebhook.js
@@ -1,0 +1,22 @@
+import { AppError } from "../utils/AppError.js";
+import { getChatbotSettings } from "../services/chatbotSettingsService.js";
+
+export async function ensureEvolutionWebhook(request, _response, next) {
+  const settings = await getChatbotSettings();
+  const expectedToken = settings.webhookToken;
+
+  if (!expectedToken) {
+    return next(new AppError("Token do webhook Evolution nao configurado no painel.", 500));
+  }
+
+  const providedToken =
+    request.headers["x-evolution-token"] ??
+    request.headers["x-webhook-token"] ??
+    request.query.token;
+
+  if (providedToken !== expectedToken) {
+    return next(new AppError("Webhook Evolution nao autorizado.", 401));
+  }
+
+  return next();
+}

--- a/apps/api/src/routes/chatbot.routes.js
+++ b/apps/api/src/routes/chatbot.routes.js
@@ -1,0 +1,111 @@
+import { Router } from "express";
+
+import { ensureAuth, ensureRole } from "../middlewares/auth.js";
+import { ensureEvolutionWebhook } from "../middlewares/evolutionWebhook.js";
+import {
+  avisarPedidoPronto,
+  consultarClienteChatbot,
+  consultarPedidoChatbot,
+  criarPedidoChatbot,
+  enviarAvisoSerasaFiado,
+  getMetricasDiariasChatbot,
+  handleEvolutionWebhook,
+} from "../services/chatbotService.js";
+import { getChatbotSettings, updateChatbotSettings } from "../services/chatbotSettingsService.js";
+import { asyncHandler } from "../utils/asyncHandler.js";
+
+const chatbotRoutes = Router();
+
+chatbotRoutes.post(
+  "/webhook/evolution",
+  ensureEvolutionWebhook,
+  asyncHandler(async (request, response) => {
+    const result = await handleEvolutionWebhook(request.body);
+
+    response.status(200).json(result);
+  }),
+);
+
+chatbotRoutes.post(
+  "/clientes/consultar",
+  ensureEvolutionWebhook,
+  asyncHandler(async (request, response) => {
+    const cliente = await consultarClienteChatbot(request.body);
+
+    response.status(200).json(cliente);
+  }),
+);
+
+chatbotRoutes.post(
+  "/pedidos",
+  ensureEvolutionWebhook,
+  asyncHandler(async (request, response) => {
+    const pedido = await criarPedidoChatbot(request.body);
+
+    response.status(201).json(pedido);
+  }),
+);
+
+chatbotRoutes.post(
+  "/pedidos/:id/consultar",
+  ensureEvolutionWebhook,
+  asyncHandler(async (request, response) => {
+    const pedido = await consultarPedidoChatbot(request.params.id, request.body);
+
+    response.status(200).json(pedido);
+  }),
+);
+
+chatbotRoutes.use(ensureAuth);
+
+chatbotRoutes.get(
+  "/configuracoes",
+  ensureRole("PROPRIETARIO"),
+  asyncHandler(async (_request, response) => {
+    const settings = await getChatbotSettings();
+
+    response.status(200).json(settings);
+  }),
+);
+
+chatbotRoutes.put(
+  "/configuracoes",
+  ensureRole("PROPRIETARIO"),
+  asyncHandler(async (request, response) => {
+    const settings = await updateChatbotSettings(request.body);
+
+    response.status(200).json(settings);
+  }),
+);
+
+chatbotRoutes.post(
+  "/pedidos/:id/pronto",
+  ensureRole("PROPRIETARIO", "ATENDENTE"),
+  asyncHandler(async (request, response) => {
+    const result = await avisarPedidoPronto(request.params.id);
+
+    response.status(200).json(result);
+  }),
+);
+
+chatbotRoutes.post(
+  "/fiado/:clienteId/aviso-serasa",
+  ensureRole("PROPRIETARIO"),
+  asyncHandler(async (request, response) => {
+    const result = await enviarAvisoSerasaFiado(request.params.clienteId);
+
+    response.status(200).json(result);
+  }),
+);
+
+chatbotRoutes.get(
+  "/metricas/diarias",
+  ensureRole("PROPRIETARIO"),
+  asyncHandler(async (_request, response) => {
+    const metrics = await getMetricasDiariasChatbot();
+
+    response.status(200).json(metrics);
+  }),
+);
+
+export { chatbotRoutes };

--- a/apps/api/src/routes/funcionarios.routes.js
+++ b/apps/api/src/routes/funcionarios.routes.js
@@ -7,6 +7,14 @@ import {
   listFuncionarios,
   updateFuncionario,
 } from "../services/funcionarioService.js";
+import {
+  gerarDadosOperacionaisFake,
+  listarPonto,
+  registrarAtestado,
+  registrarFerias,
+  registrarLicenca,
+  registrarPonto,
+} from "../services/funcionarioOperacionalService.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
 import { ensureAuth, ensureRole } from "../middlewares/auth.js";
 
@@ -29,6 +37,60 @@ funcionariosRoutes.get(
     const funcionarios = await listFuncionarios(request.query);
 
     response.status(200).json(funcionarios);
+  }),
+);
+
+funcionariosRoutes.post(
+  "/:id/ponto",
+  asyncHandler(async (request, response) => {
+    const registro = await registrarPonto(request.params.id, request.body);
+
+    response.status(201).json(registro);
+  }),
+);
+
+funcionariosRoutes.get(
+  "/:id/ponto",
+  asyncHandler(async (request, response) => {
+    const registros = await listarPonto(request.params.id, request.query);
+
+    response.status(200).json(registros);
+  }),
+);
+
+funcionariosRoutes.post(
+  "/:id/ferias",
+  asyncHandler(async (request, response) => {
+    const ferias = await registrarFerias(request.params.id, request.body);
+
+    response.status(201).json(ferias);
+  }),
+);
+
+funcionariosRoutes.post(
+  "/:id/licencas",
+  asyncHandler(async (request, response) => {
+    const licenca = await registrarLicenca(request.params.id, request.body);
+
+    response.status(201).json(licenca);
+  }),
+);
+
+funcionariosRoutes.post(
+  "/:id/atestados",
+  asyncHandler(async (request, response) => {
+    const atestado = await registrarAtestado(request.params.id, request.body);
+
+    response.status(201).json(atestado);
+  }),
+);
+
+funcionariosRoutes.post(
+  "/:id/dados-operacionais/fake",
+  asyncHandler(async (request, response) => {
+    const dados = await gerarDadosOperacionaisFake(request.params.id);
+
+    response.status(201).json(dados);
   }),
 );
 

--- a/apps/api/src/routes/funcionarios.routes.js
+++ b/apps/api/src/routes/funcionarios.routes.js
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+
 import { Router } from "express";
 
 import {
@@ -9,18 +11,37 @@ import {
 } from "../services/funcionarioService.js";
 import {
   gerarDadosOperacionaisFake,
+  listarAtestados,
   listarPonto,
   registrarAtestado,
   registrarFerias,
   registrarLicenca,
   registrarPonto,
+  uploadDocumento,
 } from "../services/funcionarioOperacionalService.js";
+import { resolveLocalDocumentoPath } from "../services/funcionarioDocumentosStorageService.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
 import { ensureAuth, ensureRole } from "../middlewares/auth.js";
+import { AppError } from "../utils/AppError.js";
 
 const funcionariosRoutes = Router();
 
 funcionariosRoutes.use(ensureAuth, ensureRole("PROPRIETARIO"));
+
+funcionariosRoutes.get(
+  "/documentos-arquivo/:funcionarioId/:fileName",
+  asyncHandler(async (request, response) => {
+    const filePath = resolveLocalDocumentoPath(request.params.funcionarioId, request.params.fileName);
+
+    try {
+      const fileBuffer = await readFile(filePath);
+      response.setHeader("Content-Type", "application/pdf");
+      response.status(200).send(fileBuffer);
+    } catch {
+      throw new AppError("Documento nao encontrado.", 404);
+    }
+  }),
+);
 
 funcionariosRoutes.post(
   "/",
@@ -73,6 +94,24 @@ funcionariosRoutes.post(
     const licenca = await registrarLicenca(request.params.id, request.body);
 
     response.status(201).json(licenca);
+  }),
+);
+
+funcionariosRoutes.get(
+  "/:id/atestados",
+  asyncHandler(async (request, response) => {
+    const atestados = await listarAtestados(request.params.id);
+
+    response.status(200).json(atestados);
+  }),
+);
+
+funcionariosRoutes.post(
+  "/:id/documentos",
+  asyncHandler(async (request, response) => {
+    const documento = await uploadDocumento(request.params.id, request.body);
+
+    response.status(201).json(documento);
   }),
 );
 

--- a/apps/api/src/routes/index.js
+++ b/apps/api/src/routes/index.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import { authRoutes } from "./auth.routes.js";
+import { chatbotRoutes } from "./chatbot.routes.js";
 import { clientesRoutes } from "./clientes.routes.js";
 import { fiadoRoutes } from "./fiado.routes.js";
 import { funcionariosRoutes } from "./funcionarios.routes.js";
@@ -20,6 +21,7 @@ router.get("/health", (_request, response) => {
 });
 
 router.use("/auth", authRoutes);
+router.use("/chatbot", chatbotRoutes);
 router.use("/clientes", clientesRoutes);
 router.use("/produtos", produtosRoutes);
 router.use("/funcionarios", funcionariosRoutes);

--- a/apps/api/src/services/chatbotService.js
+++ b/apps/api/src/services/chatbotService.js
@@ -1,0 +1,273 @@
+import { prisma } from "../config/prisma.js";
+import { StatusNotificacao } from "../domain/enums.js";
+import { AppError } from "../utils/AppError.js";
+import { parseId } from "../utils/validation.js";
+import { dispatchWhatsAppText } from "./evolutionService.js";
+import { getRelatorioDashboard, getRelatorioVendas } from "./relatorioService.js";
+import { getChatbotSettings } from "./chatbotSettingsService.js";
+
+function onlyDigits(value = "") {
+  return String(value).replace(/\D/g, "");
+}
+
+function normalizePhone(value = "") {
+  const digits = onlyDigits(value);
+
+  if (!digits) {
+    return "";
+  }
+
+  return digits.startsWith("55") ? digits : `55${digits}`;
+}
+
+async function findClienteCadastrado({ telefone, cpf }) {
+  const telefoneDigits = onlyDigits(telefone);
+  const cpfDigits = onlyDigits(cpf);
+  const clientes = await prisma.cliente.findMany({
+    where: { ativo: true },
+    include: { contaFiado: true },
+  });
+
+  return clientes.find((cliente) => {
+    const samePhone = telefoneDigits && onlyDigits(cliente.telefone).endsWith(telefoneDigits.slice(-11));
+    const sameCpf = cpfDigits && onlyDigits(cliente.cpf) === cpfDigits;
+
+    return samePhone || sameCpf;
+  });
+}
+
+export async function consultarClienteChatbot(data) {
+  const cliente = await findClienteCadastrado(data);
+
+  if (!cliente) {
+    throw new AppError("Cliente nao cadastrado. Cadastre o cliente antes de liberar pedidos pelo WhatsApp.", 403);
+  }
+
+  return {
+    id: cliente.id,
+    nome: cliente.nome,
+    telefone: cliente.telefone,
+    cpf: cliente.cpf,
+    statusSerasa: cliente.statusSerasa,
+    saldoFiado: Number(cliente.contaFiado?.saldoDevedor ?? 0),
+  };
+}
+
+export async function criarPedidoChatbot(data) {
+  const cliente = await findClienteCadastrado(data);
+
+  if (!cliente) {
+    throw new AppError("Pedidos pelo WhatsApp sao permitidos apenas para clientes cadastrados.", 403);
+  }
+
+  if (!Array.isArray(data.itens) || data.itens.length === 0) {
+    throw new AppError("Informe ao menos um item para consultar disponibilidade do pedido.", 400);
+  }
+
+  const produtoIds = data.itens.map((item) => parseId(item.produtoId, "produtoId"));
+  const produtos = await prisma.produto.findMany({
+    where: {
+      id: { in: produtoIds },
+      ativo: true,
+    },
+  });
+  const produtosById = new Map(produtos.map((produto) => [produto.id, produto]));
+  let valorEstimado = 0;
+  const itens = data.itens.map((item) => {
+    const produtoId = parseId(item.produtoId, "produtoId");
+    const quantidade = Number(item.quantidade);
+    const produto = produtosById.get(produtoId);
+
+    if (!produto || !Number.isInteger(quantidade) || quantidade <= 0) {
+      throw new AppError("Pedido contem produto inexistente ou quantidade invalida.", 400);
+    }
+
+    const subtotal = Number(produto.precoBase) * quantidade;
+    valorEstimado += subtotal;
+
+    return {
+      produtoId,
+      produto: produto.nome,
+      quantidade,
+      subtotal,
+    };
+  });
+
+  return {
+    clienteId: cliente.id,
+    cliente: cliente.nome,
+    status: "CONSULTADO",
+    valorEstimado,
+    itens,
+    mensagem: "Cliente cadastrado e itens validos. Registro persistente de pedido sera feito em modulo proprio, sem usuario operador.",
+  };
+}
+
+export async function consultarPedidoChatbot(idParam, data = {}) {
+  const id = parseId(idParam);
+  const cliente = data.telefone || data.cpf ? await findClienteCadastrado(data) : null;
+  const venda = await prisma.venda.findFirst({
+    where: {
+      id,
+      ...(cliente ? { clienteId: cliente.id } : {}),
+    },
+    include: {
+      cliente: true,
+      itens: { include: { produto: true } },
+    },
+  });
+
+  if (!venda) {
+    throw new AppError("Pedido nao encontrado para este cliente.", 404);
+  }
+
+  return {
+    pedidoId: venda.id,
+    status: venda.status,
+    cliente: venda.cliente?.nome,
+    valorTotal: Number(venda.valorTotal),
+    itens: venda.itens.map((item) => ({
+      produto: item.produto?.nome ?? "Produto nao informado",
+      quantidade: item.quantidade,
+      subtotal: Number(item.subtotal),
+    })),
+  };
+}
+
+export async function avisarPedidoPronto(idParam) {
+  const settings = await getChatbotSettings();
+
+  if (!settings.orderReadyNotificationsEnabled) {
+    throw new AppError("Avisos de pedido pronto estao desativados nas configuracoes do chatbot.", 409);
+  }
+
+  const id = parseId(idParam);
+  const venda = await prisma.venda.findUnique({
+    where: { id },
+    include: { cliente: true },
+  });
+
+  if (!venda?.cliente) {
+    throw new AppError("Pedido nao encontrado ou sem cliente vinculado.", 404);
+  }
+
+  const mensagem = `Ola, ${venda.cliente.nome}. Seu pedido ${venda.id} da Padaria Pao Fresquim esta pronto para coleta.`;
+  const dispatch = await dispatchWhatsAppText({
+    phone: normalizePhone(venda.cliente.telefone),
+    message: mensagem,
+  });
+  const updated = await prisma.venda.update({
+    where: { id },
+    data: { status: "CONCLUIDA" },
+  });
+
+  return {
+    pedidoId: updated.id,
+    status: updated.status,
+    dispatch,
+  };
+}
+
+export async function enviarAvisoSerasaFiado(clienteIdParam) {
+  const settings = await getChatbotSettings();
+
+  if (!settings.debtWarningsEnabled) {
+    throw new AppError("Avisos de fiado/Serasa estao desativados nas configuracoes do chatbot.", 409);
+  }
+
+  const clienteId = parseId(clienteIdParam, "clienteId");
+  const conta = await prisma.contaFiado.findUnique({
+    where: { clienteId },
+    include: { cliente: true },
+  });
+
+  if (!conta || Number(conta.saldoDevedor) <= 0) {
+    throw new AppError("Cliente nao possui saldo de fiado em aberto.", 404);
+  }
+
+  const mensagem = `Ola, ${conta.cliente.nome}. Consta debito de fiado de R$ ${Number(conta.saldoDevedor).toFixed(2)} na Padaria Pao Fresquim. Regularize para evitar envio ao Serasa.`;
+  const dispatch = await dispatchWhatsAppText({
+    phone: normalizePhone(conta.cliente.telefone),
+    message: mensagem,
+  });
+
+  const updated = await prisma.contaFiado.update({
+    where: { clienteId },
+    data: {
+      dataUltimaCobranca: new Date(),
+      statusNotificacao: StatusNotificacao.ENVIADA,
+    },
+  });
+
+  return {
+    clienteId,
+    saldoDevedor: Number(updated.saldoDevedor),
+    statusNotificacao: updated.statusNotificacao,
+    dispatch,
+  };
+}
+
+export async function getMetricasDiariasChatbot() {
+  const settings = await getChatbotSettings();
+
+  if (!settings.dailyMetricsEnabled) {
+    throw new AppError("Metricas diarias estao desativadas nas configuracoes do chatbot.", 409);
+  }
+
+  const hoje = new Date();
+  const dataInicio = hoje.toISOString().slice(0, 10);
+  const dashboard = await getRelatorioDashboard();
+  const vendas = await getRelatorioVendas({ dataInicio, dataFim: dataInicio });
+  const pedidosPendentes = await prisma.venda.count({
+    where: {
+      status: "PENDENTE",
+      dataHora: {
+        gte: new Date(`${dataInicio}T00:00:00.000Z`),
+      },
+    },
+  });
+
+  return {
+    ...dashboard,
+    pedidosPendentes,
+    topProducts: vendas.topProducts,
+  };
+}
+
+export async function handleEvolutionWebhook(payload) {
+  const remoteJid = payload?.data?.key?.remoteJid ?? payload?.key?.remoteJid ?? payload?.from;
+  const text =
+    payload?.data?.message?.conversation ??
+    payload?.data?.message?.extendedTextMessage?.text ??
+    payload?.message?.text ??
+    "";
+  const telefone = normalizePhone(remoteJid);
+  const cliente = telefone ? await findClienteCadastrado({ telefone }) : null;
+
+  return {
+    received: true,
+    telefone,
+    clienteCadastrado: Boolean(cliente),
+    clienteId: cliente?.id ?? null,
+    mensagem: text,
+    intent: inferIntent(text),
+  };
+}
+
+function inferIntent(text) {
+  const normalized = text.toLowerCase();
+
+  if (normalized.includes("pedido") || normalized.includes("comprar")) {
+    return "PEDIDO";
+  }
+
+  if (normalized.includes("fiado") || normalized.includes("debito") || normalized.includes("devo")) {
+    return "FIADO";
+  }
+
+  if (normalized.includes("pronto") || normalized.includes("coleta")) {
+    return "STATUS_PEDIDO";
+  }
+
+  return "ATENDIMENTO";
+}

--- a/apps/api/src/services/chatbotSettingsService.js
+++ b/apps/api/src/services/chatbotSettingsService.js
@@ -1,0 +1,63 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+const SETTINGS_PATH = resolve(process.cwd(), ".runtime", "chatbot-config.json");
+
+const DEFAULT_SETTINGS = {
+  evolutionApiUrl: "",
+  evolutionApiKey: "",
+  evolutionDispatchPath: "/message/sendText",
+  webhookToken: "",
+  ownerPhone: "",
+  orderReadyNotificationsEnabled: true,
+  debtWarningsEnabled: true,
+  dailyMetricsEnabled: true,
+};
+
+function sanitizeSettings(settings) {
+  return {
+    evolutionApiUrl: settings.evolutionApiUrl ?? "",
+    evolutionApiKey: settings.evolutionApiKey ?? "",
+    evolutionDispatchPath: settings.evolutionDispatchPath ?? "/message/sendText",
+    webhookToken: settings.webhookToken ?? "",
+    ownerPhone: settings.ownerPhone ?? "",
+    orderReadyNotificationsEnabled: Boolean(settings.orderReadyNotificationsEnabled),
+    debtWarningsEnabled: Boolean(settings.debtWarningsEnabled),
+    dailyMetricsEnabled: Boolean(settings.dailyMetricsEnabled),
+  };
+}
+
+export async function getChatbotSettings() {
+  let persisted = {};
+
+  try {
+    persisted = JSON.parse(await readFile(SETTINGS_PATH, "utf8"));
+  } catch {
+    persisted = {};
+  }
+
+  return sanitizeSettings({
+    ...DEFAULT_SETTINGS,
+    ...persisted,
+  });
+}
+
+export async function updateChatbotSettings(data) {
+  const current = await getChatbotSettings();
+  const next = sanitizeSettings({
+    ...current,
+    evolutionApiUrl: data.evolutionApiUrl,
+    evolutionApiKey: data.evolutionApiKey,
+    evolutionDispatchPath: data.evolutionDispatchPath,
+    webhookToken: data.webhookToken,
+    ownerPhone: data.ownerPhone,
+    orderReadyNotificationsEnabled: data.orderReadyNotificationsEnabled,
+    debtWarningsEnabled: data.debtWarningsEnabled,
+    dailyMetricsEnabled: data.dailyMetricsEnabled,
+  });
+
+  await mkdir(dirname(SETTINGS_PATH), { recursive: true });
+  await writeFile(SETTINGS_PATH, JSON.stringify(next, null, 2));
+
+  return next;
+}

--- a/apps/api/src/services/evolutionService.js
+++ b/apps/api/src/services/evolutionService.js
@@ -1,0 +1,49 @@
+import { AppError } from "../utils/AppError.js";
+import { getChatbotSettings } from "./chatbotSettingsService.js";
+
+function buildDispatchUrl({ baseUrl, dispatchPath }) {
+  const cleanBase = baseUrl.replace(/\/+$/, "");
+  const cleanPath = dispatchPath.replace(/^\/+/, "");
+
+  return `${cleanBase}/${cleanPath}`;
+}
+
+export async function dispatchWhatsAppText({ phone, message }) {
+  if (!phone || !message) {
+    throw new AppError("Telefone e mensagem sao obrigatorios para disparo WhatsApp.", 400);
+  }
+
+  const settings = await getChatbotSettings();
+  const config = {
+    baseUrl: settings.evolutionApiUrl,
+    apiKey: settings.evolutionApiKey,
+    dispatchPath: settings.evolutionDispatchPath,
+  };
+
+  if (!config.baseUrl) {
+    return {
+      skipped: true,
+      reason: "EVOLUTION_API_URL nao configurada.",
+    };
+  }
+
+  const response = await fetch(buildDispatchUrl(config), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(config.apiKey ? { apikey: config.apiKey } : {}),
+    },
+    body: JSON.stringify({
+      number: phone,
+      text: message,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+
+    throw new AppError(`Falha no disparo Evolution: ${body || response.statusText}`, 502);
+  }
+
+  return response.json().catch(() => ({ ok: true }));
+}

--- a/apps/api/src/services/funcionarioDocumentosStorageService.js
+++ b/apps/api/src/services/funcionarioDocumentosStorageService.js
@@ -1,0 +1,88 @@
+// apps/api/src/services/funcionarioDocumentosStorageService.js
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { AppError } from "../utils/AppError.js";
+
+const MAX_PDF_BYTES = 10 * 1024 * 1024;
+
+function getSupabaseConfig() {
+  return {
+    projectUrl: process.env.SUPABASE_PROJECT_URL?.replace(/\/$/, ""),
+    serviceRoleKey: process.env.SUPABASE_SERVICE_ROLE_KEY,
+    bucket:
+      process.env.SUPABASE_STORAGE_BUCKET_FUNCIONARIOS ??
+      process.env.SUPABASE_STORAGE_BUCKET_PRODUTOS ??
+      "funcionarios-documentos",
+  };
+}
+
+function sanitizeFileName(fileName) {
+  return String(fileName ?? "documento.pdf").replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+async function uploadToSupabase(funcionarioId, fileName, buffer) {
+  const { projectUrl, serviceRoleKey, bucket } = getSupabaseConfig();
+
+  if (!projectUrl || !serviceRoleKey) {
+    return null;
+  }
+
+  const objectPath = `${funcionarioId}/${Date.now()}-${sanitizeFileName(fileName)}`;
+  const response = await fetch(`${projectUrl}/storage/v1/object/${bucket}/${objectPath}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${serviceRoleKey}`,
+      "Content-Type": "application/pdf",
+      "x-upsert": "false",
+    },
+    body: buffer,
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    console.warn(`Supabase storage upload failed for employee ${funcionarioId}: ${details}`);
+    return null;
+  }
+
+  return `${projectUrl}/storage/v1/object/public/${bucket}/${objectPath}`;
+}
+
+async function uploadToLocalRuntime(funcionarioId, fileName, buffer) {
+  const safeName = `${Date.now()}-${sanitizeFileName(fileName)}`;
+  const relativeDir = path.join(String(funcionarioId));
+  const absoluteDir = path.resolve(process.cwd(), ".runtime", "documentos", relativeDir);
+
+  await mkdir(absoluteDir, { recursive: true });
+  await writeFile(path.join(absoluteDir, safeName), buffer);
+
+  return `/api/funcionarios/documentos-arquivo/${funcionarioId}/${safeName}`;
+}
+
+export async function uploadFuncionarioPdf(funcionarioId, fileName, buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    throw new AppError("Arquivo PDF vazio ou invalido.", 400);
+  }
+
+  if (buffer.length > MAX_PDF_BYTES) {
+    throw new AppError("PDF maior que 10MB.", 400);
+  }
+
+  const supabaseUrl = await uploadToSupabase(funcionarioId, fileName, buffer);
+
+  if (supabaseUrl) {
+    return supabaseUrl;
+  }
+
+  return uploadToLocalRuntime(funcionarioId, fileName, buffer);
+}
+
+export function resolveLocalDocumentoPath(funcionarioId, fileName) {
+  const safeName = sanitizeFileName(fileName);
+
+  if (!safeName || safeName.includes("..") || safeName.includes("/") || safeName.includes("\\")) {
+    throw new AppError("Nome de arquivo invalido.", 400);
+  }
+
+  return path.resolve(process.cwd(), ".runtime", "documentos", String(funcionarioId), safeName);
+}

--- a/apps/api/src/services/funcionarioOperacionalService.js
+++ b/apps/api/src/services/funcionarioOperacionalService.js
@@ -1,4 +1,5 @@
 import { prisma } from "../config/prisma.js";
+import { uploadFuncionarioPdf } from "./funcionarioDocumentosStorageService.js";
 import { AppError } from "../utils/AppError.js";
 import { ensureEnumValue, parseId, requireFields } from "../utils/validation.js";
 
@@ -98,6 +99,34 @@ export async function registrarLicenca(funcionarioId, data) {
       retornoPrevistoEm: data.retornoPrevistoEm ? parseDate(data.retornoPrevistoEm, "retornoPrevistoEm") : null,
       observacao: data.observacao,
     },
+  });
+}
+
+export async function listarAtestados(funcionarioId) {
+  const id = parseId(funcionarioId);
+  await ensureFuncionario(id);
+
+  return prisma.atestado.findMany({
+    where: { funcionarioId: id },
+    orderBy: { dataEntrega: "desc" },
+  });
+}
+
+export async function uploadDocumento(funcionarioId, data) {
+  requireFields(data, ["fileName", "contentBase64", "dataEntrega"]);
+
+  const buffer = Buffer.from(data.contentBase64, "base64");
+
+  if (!buffer.length) {
+    throw new AppError("Conteudo do PDF invalido.", 400);
+  }
+
+  const arquivoUrl = await uploadFuncionarioPdf(funcionarioId, data.fileName, buffer);
+
+  return registrarAtestado(funcionarioId, {
+    arquivoUrl,
+    dataEntrega: data.dataEntrega,
+    observacao: data.observacao,
   });
 }
 

--- a/apps/api/src/services/funcionarioOperacionalService.js
+++ b/apps/api/src/services/funcionarioOperacionalService.js
@@ -1,0 +1,169 @@
+import { prisma } from "../config/prisma.js";
+import { AppError } from "../utils/AppError.js";
+import { ensureEnumValue, parseId, requireFields } from "../utils/validation.js";
+
+async function ensureFuncionario(idParam) {
+  const id = parseId(idParam);
+  const funcionario = await prisma.funcionario.findFirst({
+    where: { id, ativo: true },
+  });
+
+  if (!funcionario) {
+    throw new AppError("Funcionario nao encontrado ou inativo.", 404);
+  }
+
+  return funcionario;
+}
+
+function parseDate(value, fieldName) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new AppError(`O campo ${fieldName} deve conter uma data valida.`, 400);
+  }
+
+  return date;
+}
+
+export async function registrarPonto(funcionarioId, data) {
+  await ensureFuncionario(funcionarioId);
+  requireFields(data, ["tipoRegistro"]);
+  ensureEnumValue(data.tipoRegistro, ["ENTRADA", "SAIDA"], "tipoRegistro");
+
+  return prisma.registroPonto.create({
+    data: {
+      funcionarioId: parseId(funcionarioId),
+      tipoRegistro: data.tipoRegistro,
+      dataHoraBatida: data.dataHoraBatida ? parseDate(data.dataHoraBatida, "dataHoraBatida") : undefined,
+    },
+  });
+}
+
+export async function listarPonto(funcionarioId, { mes, ano } = {}) {
+  const id = parseId(funcionarioId);
+  await ensureFuncionario(id);
+  const where = { funcionarioId: id };
+
+  if (mes && ano) {
+    const month = Number(mes) - 1;
+    const year = Number(ano);
+
+    if (month < 0 || month > 11 || !Number.isInteger(year)) {
+      throw new AppError("Filtros mes e ano invalidos.", 400);
+    }
+
+    where.dataHoraBatida = {
+      gte: new Date(year, month, 1),
+      lt: new Date(year, month + 1, 1),
+    };
+  }
+
+  return prisma.registroPonto.findMany({
+    where,
+    orderBy: { dataHoraBatida: "desc" },
+  });
+}
+
+export async function registrarFerias(funcionarioId, data) {
+  const funcionario = await ensureFuncionario(funcionarioId);
+  requireFields(data, ["dataInicio", "dataFim"]);
+  const dataInicio = parseDate(data.dataInicio, "dataInicio");
+  const direitoEm = new Date(funcionario.dataAdmissao);
+
+  direitoEm.setFullYear(direitoEm.getFullYear() + 1);
+
+  if (dataInicio < direitoEm) {
+    throw new AppError(`Funcionario so adquire direito a ferias em ${direitoEm.toISOString().slice(0, 10)}.`, 400);
+  }
+
+  return prisma.ferias.create({
+    data: {
+      funcionarioId: funcionario.id,
+      dataInicio,
+      dataFim: parseDate(data.dataFim, "dataFim"),
+      observacao: data.observacao,
+    },
+  });
+}
+
+export async function registrarLicenca(funcionarioId, data) {
+  await ensureFuncionario(funcionarioId);
+  requireFields(data, ["tipo", "dataInicio"]);
+
+  return prisma.licenca.create({
+    data: {
+      funcionarioId: parseId(funcionarioId),
+      tipo: data.tipo,
+      dataInicio: parseDate(data.dataInicio, "dataInicio"),
+      retornoPrevistoEm: data.retornoPrevistoEm ? parseDate(data.retornoPrevistoEm, "retornoPrevistoEm") : null,
+      observacao: data.observacao,
+    },
+  });
+}
+
+export async function registrarAtestado(funcionarioId, data) {
+  await ensureFuncionario(funcionarioId);
+  requireFields(data, ["arquivoUrl", "dataEntrega"]);
+
+  return prisma.atestado.create({
+    data: {
+      funcionarioId: parseId(funcionarioId),
+      arquivoUrl: data.arquivoUrl,
+      dataEntrega: parseDate(data.dataEntrega, "dataEntrega"),
+      observacao: data.observacao,
+    },
+  });
+}
+
+export async function gerarDadosOperacionaisFake(funcionarioId) {
+  const funcionario = await ensureFuncionario(funcionarioId);
+  const now = new Date();
+  const todayStart = new Date(now);
+
+  todayStart.setHours(8, 0, 0, 0);
+
+  const todayEnd = new Date(now);
+  todayEnd.setHours(17, 30, 0, 0);
+
+  const nextVacationStart = new Date(now);
+  nextVacationStart.setMonth(nextVacationStart.getMonth() + 2);
+
+  const nextVacationEnd = new Date(nextVacationStart);
+  nextVacationEnd.setDate(nextVacationEnd.getDate() + 14);
+
+  const [entrada, saida, ferias, licenca, atestado] = await prisma.$transaction([
+    prisma.registroPonto.create({
+      data: { funcionarioId: funcionario.id, tipoRegistro: "ENTRADA", dataHoraBatida: todayStart },
+    }),
+    prisma.registroPonto.create({
+      data: { funcionarioId: funcionario.id, tipoRegistro: "SAIDA", dataHoraBatida: todayEnd },
+    }),
+    prisma.ferias.create({
+      data: {
+        funcionarioId: funcionario.id,
+        dataInicio: nextVacationStart,
+        dataFim: nextVacationEnd,
+        observacao: "Registro fake gerado para prototipo.",
+      },
+    }),
+    prisma.licenca.create({
+      data: {
+        funcionarioId: funcionario.id,
+        tipo: "Treinamento",
+        dataInicio: now,
+        retornoPrevistoEm: now,
+        observacao: "Licenca fake de demonstracao.",
+      },
+    }),
+    prisma.atestado.create({
+      data: {
+        funcionarioId: funcionario.id,
+        arquivoUrl: "https://example.com/atestados/fake.pdf",
+        dataEntrega: now,
+        observacao: "Atestado fake de demonstracao.",
+      },
+    }),
+  ]);
+
+  return { entrada, saida, ferias, licenca, atestado };
+}

--- a/apps/api/src/services/funcionarioOperacionalService.js
+++ b/apps/api/src/services/funcionarioOperacionalService.js
@@ -160,7 +160,7 @@ export async function gerarDadosOperacionaisFake(funcionarioId) {
   const nextVacationEnd = new Date(nextVacationStart);
   nextVacationEnd.setDate(nextVacationEnd.getDate() + 14);
 
-  const [entrada, saida, ferias, licenca, atestado] = await prisma.$transaction([
+  const [entrada, saida, ferias, licenca] = await prisma.$transaction([
     prisma.registroPonto.create({
       data: { funcionarioId: funcionario.id, tipoRegistro: "ENTRADA", dataHoraBatida: todayStart },
     }),
@@ -184,15 +184,7 @@ export async function gerarDadosOperacionaisFake(funcionarioId) {
         observacao: "Licenca fake de demonstracao.",
       },
     }),
-    prisma.atestado.create({
-      data: {
-        funcionarioId: funcionario.id,
-        arquivoUrl: "https://example.com/atestados/fake.pdf",
-        dataEntrega: now,
-        observacao: "Atestado fake de demonstracao.",
-      },
-    }),
   ]);
 
-  return { entrada, saida, ferias, licenca, atestado };
+  return { entrada, saida, ferias, licenca };
 }

--- a/apps/web/src/app/app.routes.ts
+++ b/apps/web/src/app/app.routes.ts
@@ -6,6 +6,8 @@ import { LoginComponent } from "./features/login/login.component";
 import { DashboardComponent } from "./features/dashboard/dashboard.component";
 import { ClientsComponent } from "./features/clients/clients.component";
 import { EmployeesComponent } from "./features/employees/employees.component";
+import { EmployeeTimecardComponent } from "./features/employees/employee-timecard.component";
+import { EmployeeDocumentsComponent } from "./features/employees/employee-documents.component";
 import { SaleComponent } from "./features/sale/sale.component";
 import { HistoryComponent } from "./features/history/history.component";
 import { DebtsComponent } from "./features/debts/debts.component";
@@ -35,6 +37,16 @@ export const routes: Routes = [
         data: { pageId: "produtos" },
       },
       { path: "funcionarios", component: EmployeesComponent, data: { pageId: "funcionarios" } },
+      {
+        path: "funcionarios/:employeeId/ponto",
+        component: EmployeeTimecardComponent,
+        data: { pageId: "funcionarios" },
+      },
+      {
+        path: "funcionarios/:employeeId/documentos",
+        component: EmployeeDocumentsComponent,
+        data: { pageId: "funcionarios" },
+      },
       { path: "vendas/nova", component: SaleComponent, data: { pageId: "nova-venda" } },
       { path: "historico", component: HistoryComponent, data: { pageId: "historico" } },
       { path: "fiado", component: DebtsComponent, data: { pageId: "fiado" } },

--- a/apps/web/src/app/core/interceptors/auth.interceptor.ts
+++ b/apps/web/src/app/core/interceptors/auth.interceptor.ts
@@ -1,18 +1,29 @@
 import { HttpInterceptorFn } from "@angular/common/http";
 import { inject } from "@angular/core";
+import { Router } from "@angular/router";
+import { catchError, throwError } from "rxjs";
 import { AuthService } from "../services/auth.service";
 
 export const authInterceptor: HttpInterceptorFn = (request, next) => {
   const authService = inject(AuthService);
+  const router = inject(Router);
   const token = authService.getToken();
+  const handleUnauthorized = (error: { status?: number }) => {
+    if (error.status === 401 && !request.url.includes("/api/auth/login")) {
+      authService.logout();
+      void router.navigateByUrl("/login");
+    }
+
+    return throwError(() => error);
+  };
 
   if (!token) {
-    return next(request);
+    return next(request).pipe(catchError(handleUnauthorized));
   }
 
   return next(request.clone({
     setHeaders: {
       Authorization: `Bearer ${token}`,
     },
-  }));
+  })).pipe(catchError(handleUnauthorized));
 };

--- a/apps/web/src/app/core/services/chatbot-api.service.ts
+++ b/apps/web/src/app/core/services/chatbot-api.service.ts
@@ -1,0 +1,52 @@
+import { HttpClient, HttpHeaders } from "@angular/common/http";
+import { Injectable, inject } from "@angular/core";
+import { Observable } from "rxjs";
+import { timeout } from "rxjs/operators";
+
+const API_BASE_URL = "http://localhost:3333";
+const NO_CACHE_HEADERS = new HttpHeaders({
+  "Cache-Control": "no-cache",
+  Pragma: "no-cache",
+});
+
+export type ChatbotSettings = {
+  evolutionApiUrl: string;
+  evolutionApiKey: string;
+  evolutionDispatchPath: string;
+  webhookToken: string;
+  ownerPhone: string;
+  orderReadyNotificationsEnabled: boolean;
+  debtWarningsEnabled: boolean;
+  dailyMetricsEnabled: boolean;
+};
+
+export type ChatbotDailyMetrics = {
+  totalSoldToday: number;
+  salesCount: number;
+  averageTicket: number;
+  debtClients: number;
+  comparedToYesterday: number;
+  pedidosPendentes: number;
+  topProducts: Array<{ name: string; sales: number; revenue: number }>;
+};
+
+@Injectable({ providedIn: "root" })
+export class ChatbotApiService {
+  private readonly http = inject(HttpClient);
+
+  getSettings(): Observable<ChatbotSettings> {
+    return this.http
+      .get<ChatbotSettings>(`${API_BASE_URL}/api/chatbot/configuracoes`, { headers: NO_CACHE_HEADERS })
+      .pipe(timeout(8000));
+  }
+
+  updateSettings(settings: ChatbotSettings): Observable<ChatbotSettings> {
+    return this.http.put<ChatbotSettings>(`${API_BASE_URL}/api/chatbot/configuracoes`, settings);
+  }
+
+  getDailyMetrics(): Observable<ChatbotDailyMetrics> {
+    return this.http
+      .get<ChatbotDailyMetrics>(`${API_BASE_URL}/api/chatbot/metricas/diarias`, { headers: NO_CACHE_HEADERS })
+      .pipe(timeout(8000));
+  }
+}

--- a/apps/web/src/app/core/services/employees-api.service.ts
+++ b/apps/web/src/app/core/services/employees-api.service.ts
@@ -74,6 +74,12 @@ export class EmployeesApiService {
     return this.http.delete<void>(`${API_BASE_URL}/api/funcionarios/${employeeId}`);
   }
 
+  getEmployee(employeeId: number): Observable<Employee> {
+    return this.http
+      .get<Employee>(`${API_BASE_URL}/api/funcionarios/${employeeId}`, { headers: NO_CACHE_HEADERS })
+      .pipe(map((employee) => this.normalizeEmployee(employee)));
+  }
+
   normalizeEmployee(employee: Employee): Employee {
     const nome = employee.nome ?? employee.name;
     const cargo = employee.cargo ?? employee.role;

--- a/apps/web/src/app/core/services/employees-operations-api.service.ts
+++ b/apps/web/src/app/core/services/employees-operations-api.service.ts
@@ -1,6 +1,12 @@
-import { HttpClient } from "@angular/common/http";
+// apps/web/src/app/core/services/employees-operations-api.service.ts
+import { HttpClient, HttpHeaders } from "@angular/common/http";
 import { Injectable, inject } from "@angular/core";
 import { Observable } from "rxjs";
+
+const NO_CACHE_HEADERS = new HttpHeaders({
+  "Cache-Control": "no-cache",
+  Pragma: "no-cache",
+});
 
 const API_BASE_URL = "http://localhost:3333";
 
@@ -11,12 +17,40 @@ export type PointRecord = {
   funcionarioId: number;
 };
 
+export type EmployeeDocument = {
+  id: number;
+  arquivoUrl: string;
+  dataEntrega: string;
+  observacao?: string | null;
+  funcionarioId: number;
+};
+
+export type UploadDocumentPayload = {
+  fileName: string;
+  contentBase64: string;
+  dataEntrega: string;
+  observacao?: string;
+};
+
 @Injectable({ providedIn: "root" })
 export class EmployeesOperationsApiService {
   private readonly http = inject(HttpClient);
 
-  listPointRecords(employeeId: number): Observable<PointRecord[]> {
-    return this.http.get<PointRecord[]>(`${API_BASE_URL}/api/funcionarios/${employeeId}/ponto`);
+  listPointRecords(employeeId: number, filters?: { mes?: number; ano?: number }): Observable<PointRecord[]> {
+    const params: Record<string, string> = {};
+
+    if (filters?.mes) {
+      params["mes"] = String(filters.mes);
+    }
+
+    if (filters?.ano) {
+      params["ano"] = String(filters.ano);
+    }
+
+    return this.http.get<PointRecord[]>(`${API_BASE_URL}/api/funcionarios/${employeeId}/ponto`, {
+      params,
+      headers: NO_CACHE_HEADERS,
+    });
   }
 
   registerPoint(employeeId: number, tipoRegistro: "ENTRADA" | "SAIDA"): Observable<PointRecord> {
@@ -25,7 +59,23 @@ export class EmployeesOperationsApiService {
     });
   }
 
+  listDocuments(employeeId: number): Observable<EmployeeDocument[]> {
+    return this.http.get<EmployeeDocument[]>(`${API_BASE_URL}/api/funcionarios/${employeeId}/atestados`);
+  }
+
+  uploadDocument(employeeId: number, payload: UploadDocumentPayload): Observable<EmployeeDocument> {
+    return this.http.post<EmployeeDocument>(`${API_BASE_URL}/api/funcionarios/${employeeId}/documentos`, payload);
+  }
+
   generateFakeOperationalData(employeeId: number): Observable<unknown> {
     return this.http.post<unknown>(`${API_BASE_URL}/api/funcionarios/${employeeId}/dados-operacionais/fake`, {});
+  }
+
+  resolveDocumentUrl(arquivoUrl: string): string {
+    if (arquivoUrl.startsWith("http://") || arquivoUrl.startsWith("https://")) {
+      return arquivoUrl;
+    }
+
+    return `${API_BASE_URL}${arquivoUrl.startsWith("/") ? "" : "/"}${arquivoUrl}`;
   }
 }

--- a/apps/web/src/app/core/services/employees-operations-api.service.ts
+++ b/apps/web/src/app/core/services/employees-operations-api.service.ts
@@ -1,0 +1,31 @@
+import { HttpClient } from "@angular/common/http";
+import { Injectable, inject } from "@angular/core";
+import { Observable } from "rxjs";
+
+const API_BASE_URL = "http://localhost:3333";
+
+export type PointRecord = {
+  id: number;
+  dataHoraBatida: string;
+  tipoRegistro: "ENTRADA" | "SAIDA";
+  funcionarioId: number;
+};
+
+@Injectable({ providedIn: "root" })
+export class EmployeesOperationsApiService {
+  private readonly http = inject(HttpClient);
+
+  listPointRecords(employeeId: number): Observable<PointRecord[]> {
+    return this.http.get<PointRecord[]>(`${API_BASE_URL}/api/funcionarios/${employeeId}/ponto`);
+  }
+
+  registerPoint(employeeId: number, tipoRegistro: "ENTRADA" | "SAIDA"): Observable<PointRecord> {
+    return this.http.post<PointRecord>(`${API_BASE_URL}/api/funcionarios/${employeeId}/ponto`, {
+      tipoRegistro,
+    });
+  }
+
+  generateFakeOperationalData(employeeId: number): Observable<unknown> {
+    return this.http.post<unknown>(`${API_BASE_URL}/api/funcionarios/${employeeId}/dados-operacionais/fake`, {});
+  }
+}

--- a/apps/web/src/app/features/chatbot/chatbot.component.css
+++ b/apps/web/src/app/features/chatbot/chatbot.component.css
@@ -92,6 +92,23 @@
   gap: 0.8rem;
 }
 
+.metrics-list {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.metrics-list div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.metrics-list span {
+  color: var(--text-muted);
+}
+
 @media (max-width: 1100px) {
   .chat-layout {
     grid-template-columns: 1fr;

--- a/apps/web/src/app/features/chatbot/chatbot.component.html
+++ b/apps/web/src/app/features/chatbot/chatbot.component.html
@@ -22,7 +22,7 @@
       <input class="chat-input" [(ngModel)]="prompt" placeholder="Como foram minhas vendas nesta semana?" />
       <button class="chat-send" type="button" (click)="sendMessage()">Enviar</button>
     </div>
-    <div class="chat-disclaimer">As respostas sao simuladas localmente para este prototipo.</div>
+    <div class="chat-disclaimer">As respostas usam as rotas do chatbot e metricas reais da API quando disponiveis.</div>
   </div>
 
   <div class="chat-sidebar">
@@ -33,18 +33,30 @@
           <div class="sugg-icon">*</div>
           <div>
             <div class="sugg-title">{{ item }}</div>
-            <div class="sugg-sub">Executar analise com dados simulados.</div>
+            <div class="sugg-sub">Consultar metricas pela API.</div>
           </div>
         </button>
       </div>
     </div>
 
     <div class="panel">
+      <div class="panel-title">Metricas diarias</div>
+      <div *ngIf="isLoading" class="docs-card-sub">Carregando metricas...</div>
+      <div *ngIf="!isLoading && errorMessage" class="docs-card-sub">{{ errorMessage }}</div>
+      <div *ngIf="metrics" class="metrics-list">
+        <div><span>Vendas hoje</span><strong>{{ formatCurrency(metrics.totalSoldToday) }}</strong></div>
+        <div><span>Pedidos pendentes</span><strong>{{ metrics.pedidosPendentes }}</strong></div>
+        <div><span>Fiado aberto</span><strong>{{ metrics.debtClients }}</strong></div>
+      </div>
+      <button class="btn-secondary compact" type="button" (click)="retry()">Atualizar</button>
+    </div>
+
+    <div class="panel">
       <div class="panel-title">Documentacao</div>
       <div class="docs-card">
-        <div class="docs-card-title">Como usar a IA</div>
-        <div class="docs-card-sub">Aprenda a fazer perguntas mais precisas.</div>
-        <a class="btn-secondary compact" routerLink="/relatorios">Ver guia</a>
+        <div class="docs-card-title">Fluxos conectados</div>
+        <div class="docs-card-sub">Pedidos somente para clientes cadastrados, coleta via Evolution, fiado/Serasa e metricas do Sr. Joaquim.</div>
+        <a class="btn-secondary compact" routerLink="/configuracoes">Configurar</a>
       </div>
     </div>
   </div>

--- a/apps/web/src/app/features/chatbot/chatbot.component.ts
+++ b/apps/web/src/app/features/chatbot/chatbot.component.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
-import { RouterLink } from "@angular/router";
-import { clients, debtors, reports, weeklySales } from "../../core/mock-data";
-import { StorageService } from "../../core/services/storage.service";
+import { NavigationEnd, Router, RouterLink } from "@angular/router";
+import { Subscription, filter } from "rxjs";
 import { ChatMessage } from "../../core/models";
+import { ChatbotApiService, ChatbotDailyMetrics } from "../../core/services/chatbot-api.service";
 import { formatCurrency } from "../../core/utils/format";
 
 @Component({
@@ -14,50 +14,111 @@ import { formatCurrency } from "../../core/utils/format";
   templateUrl: "./chatbot.component.html",
   styleUrl: "./chatbot.component.css"
 })
-export class ChatbotComponent {
+export class ChatbotComponent implements OnInit, OnDestroy {
   prompt = "";
-  messages = this.storageService.getChatMessages();
+  messages: ChatMessage[] = [
+    {
+      role: "assistant",
+      title: "Valor AI",
+      message: "Chatbot integrado as rotas de pedidos, fiado, Evolution e metricas diarias.",
+      meta: "API",
+    },
+  ];
+  metrics: ChatbotDailyMetrics | null = null;
+  isLoading = true;
+  errorMessage = "";
+  private readonly routeSubscription: Subscription;
+  readonly formatCurrency = formatCurrency;
 
-  constructor(private readonly storageService: StorageService) {}
+  constructor(
+    private readonly chatbotApiService: ChatbotApiService,
+    private readonly router: Router,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly ngZone: NgZone,
+  ) {
+    this.routeSubscription = this.router.events
+      .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
+      .subscribe((event) => {
+        if (event.urlAfterRedirects.startsWith("/chatbot")) {
+          this.loadMetrics();
+        }
+      });
+  }
+
+  ngOnInit(): void {
+    this.loadMetrics();
+  }
+
+  ngOnDestroy(): void {
+    this.routeSubscription.unsubscribe();
+  }
 
   sendMessage(content = this.prompt.trim()): void {
     if (!content) {
       return;
     }
 
-    const nextMessages: ChatMessage[] = [
+    this.messages = [
       ...this.messages,
       { role: "user", title: "Arthur", message: content, meta: "Agora" },
-      { role: "assistant", title: "Valor AI", message: this.generateChatResponse(content), meta: "Agora" }
+      { role: "assistant", title: "Valor AI", message: this.generateChatResponse(content), meta: "API" },
     ];
-
-    this.messages = nextMessages;
-    this.storageService.saveChatMessages(nextMessages);
     this.prompt = "";
+  }
+
+  retry(): void {
+    this.loadMetrics();
+  }
+
+  private loadMetrics(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.changeDetectorRef.detectChanges();
+
+    this.chatbotApiService.getDailyMetrics().subscribe({
+      next: (metrics) => {
+        this.ngZone.run(() => {
+          this.metrics = metrics;
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+      error: () => {
+        this.ngZone.run(() => {
+          this.metrics = null;
+          this.errorMessage = "API do chatbot indisponivel para metricas diarias.";
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+    });
   }
 
   private generateChatResponse(input: string): string {
     const normalized = input.toLowerCase();
 
-    if (normalized.includes("inadimpl") || normalized.includes("deve")) {
-      const topDebtors = debtors
-        .map((debtor) => ({ ...debtor, client: clients.find((item) => item.id === debtor.clientId)?.name ?? "Cliente" }))
-        .sort((a, b) => b.amount - a.amount)
-        .slice(0, 3)
-        .map((item) => `${item.client} (${formatCurrency(item.amount)})`)
-        .join(", ");
-      return `Hoje os principais devedores sao ${topDebtors}.`;
+    if (!this.metrics) {
+      return "Ainda nao consegui consultar a API do chatbot. Verifique autenticacao e backend.";
     }
 
-    if (normalized.includes("venda") || normalized.includes("semana")) {
-      const total = weeklySales.reduce((sum, item) => sum + item.value, 0);
-      return `Na semana simulada voce acumulou ${formatCurrency(total)} em vendas.`;
+    if (normalized.includes("inadimpl") || normalized.includes("fiado") || normalized.includes("deve")) {
+      return `Hoje existem ${this.metrics.debtClients} cliente(s) com fiado em aberto. A rota administrativa permite disparar aviso de Serasa por cliente.`;
+    }
+
+    if (normalized.includes("pedido") || normalized.includes("coleta") || normalized.includes("pronto")) {
+      return `Ha ${this.metrics.pedidosPendentes} pedido(s) pendente(s). Quando um pedido ficar pronto, a API envia a notificacao pela Evolution.`;
+    }
+
+    if (normalized.includes("venda") || normalized.includes("hoje") || normalized.includes("dia")) {
+      return `Hoje foram ${this.metrics.salesCount} venda(s), totalizando ${formatCurrency(this.metrics.totalSoldToday)} com ticket medio de ${formatCurrency(this.metrics.averageTicket)}.`;
     }
 
     if (normalized.includes("produto")) {
-      return `Os produtos com maior destaque no periodo sao ${reports.topProducts.map((item) => item.name).join(", ")}.`;
+      const products = this.metrics.topProducts.map((item) => `${item.name} (${item.sales})`).join(", ");
+
+      return products ? `Produtos em destaque hoje: ${products}.` : "Ainda nao ha produtos vendidos no periodo consultado.";
     }
 
-    return "Consigo responder sobre vendas, produtos, inadimplencia, cameras e indicadores com base nos dados simulados.";
+    return "Posso consultar pedidos, fiado, avisos de coleta e metricas diarias pelas novas rotas do chatbot.";
   }
 }

--- a/apps/web/src/app/features/employees/employee-documents.component.css
+++ b/apps/web/src/app/features/employees/employee-documents.component.css
@@ -1,0 +1,23 @@
+/* apps/web/src/app/features/employees/employee-documents.component.css */
+:host {
+  display: block;
+}
+
+.operations-success,
+.operations-error {
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  border: 1px solid;
+}
+
+.operations-success {
+  border-color: #bbf7d0;
+  color: #166534;
+  background: #f0fdf4;
+}
+
+.operations-error {
+  border-color: #fecaca;
+  color: #991b1b;
+  background: #fef2f2;
+}

--- a/apps/web/src/app/features/employees/employee-documents.component.html
+++ b/apps/web/src/app/features/employees/employee-documents.component.html
@@ -1,0 +1,53 @@
+<div class="employee-ops-page">
+  <div class="employee-ops-header">
+    <div>
+      <div class="employee-ops-title">Documentos</div>
+      <div class="employee-ops-subtitle">{{ employeeName }} · upload de PDF para storage</div>
+    </div>
+    <div class="employee-ops-actions">
+      <a class="btn-secondary" routerLink="/funcionarios">Voltar</a>
+      <a class="btn-secondary" [routerLink]="['/funcionarios', employeeId, 'ponto']">Cartao de ponto</a>
+    </div>
+  </div>
+
+  <div class="documents-panel">
+    <div class="documents-upload">
+      <strong>Enviar novo PDF</strong>
+      <div class="documents-upload-grid">
+        <div class="form-group documents-upload-full">
+          <label class="form-label">Arquivo PDF</label>
+          <input class="form-input" type="file" accept="application/pdf" (change)="onFileSelected($event)" />
+        </div>
+        <div class="form-group">
+          <label class="form-label">Data de entrega</label>
+          <input class="form-input" type="date" [(ngModel)]="dataEntrega" />
+        </div>
+        <div class="form-group">
+          <label class="form-label">Observacao</label>
+          <input class="form-input" type="text" [(ngModel)]="observacao" placeholder="Ex: atestado medico" />
+        </div>
+      </div>
+      <button class="btn-primary" type="button" [disabled]="isUploading" (click)="uploadDocument()">
+        {{ isUploading ? 'Enviando...' : 'Enviar para storage' }}
+      </button>
+    </div>
+
+    <div *ngIf="successMessage" class="operations-success documents-list">{{ successMessage }}</div>
+    <div *ngIf="errorMessage" class="operations-error documents-list">{{ errorMessage }}</div>
+
+    <div class="documents-list">
+      <strong>Documentos enviados</strong>
+      <div *ngIf="isLoading" class="empty-state">Carregando documentos...</div>
+      <div *ngIf="!isLoading && documents.length === 0" class="empty-state">Nenhum documento cadastrado.</div>
+
+      <div *ngFor="let document of documents" class="document-row">
+        <div class="document-meta">
+          <strong>PDF #{{ document.id }}</strong>
+          <span>Entrega: {{ document.dataEntrega | date: 'dd/MM/yyyy' }}</span>
+          <span>{{ document.observacao || 'Sem observacao' }}</span>
+        </div>
+        <button class="btn-secondary" type="button" (click)="openDocument(document)">Abrir PDF</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/web/src/app/features/employees/employee-documents.component.html
+++ b/apps/web/src/app/features/employees/employee-documents.component.html
@@ -16,7 +16,7 @@
       <div class="documents-upload-grid">
         <div class="form-group documents-upload-full">
           <label class="form-label">Arquivo PDF</label>
-          <input class="form-input" type="file" accept="application/pdf" (change)="onFileSelected($event)" />
+          <input #fileInput class="form-input" type="file" accept="application/pdf" (change)="onFileSelected($event)" />
         </div>
         <div class="form-group">
           <label class="form-label">Data de entrega</label>

--- a/apps/web/src/app/features/employees/employee-documents.component.ts
+++ b/apps/web/src/app/features/employees/employee-documents.component.ts
@@ -1,14 +1,26 @@
 // apps/web/src/app/features/employees/employee-documents.component.ts
 import { CommonModule } from "@angular/common";
-import { Component, OnInit, inject } from "@angular/core";
+import {
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  inject,
+} from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { ActivatedRoute, Router, RouterLink } from "@angular/router";
 import { HttpClient } from "@angular/common/http";
+import { Subscription } from "rxjs";
 import { EmployeesApiService } from "../../core/services/employees-api.service";
 import {
   EmployeeDocument,
   EmployeesOperationsApiService,
 } from "../../core/services/employees-operations-api.service";
+
+const API_BASE_URL = "http://localhost:3333";
 
 @Component({
   selector: "pf-employee-documents",
@@ -17,12 +29,18 @@ import {
   templateUrl: "./employee-documents.component.html",
   styleUrls: ["./employee-ops.shared.css", "./employee-documents.component.css"],
 })
-export class EmployeeDocumentsComponent implements OnInit {
+export class EmployeeDocumentsComponent implements OnInit, OnDestroy {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly http = inject(HttpClient);
   private readonly employeesApiService = inject(EmployeesApiService);
   private readonly operationsApiService = inject(EmployeesOperationsApiService);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly ngZone = inject(NgZone);
+
+  private routeSubscription?: Subscription;
+
+  @ViewChild("fileInput") fileInput?: ElementRef<HTMLInputElement>;
 
   employeeId = 0;
   employeeName = "";
@@ -36,16 +54,24 @@ export class EmployeeDocumentsComponent implements OnInit {
   successMessage = "";
 
   ngOnInit(): void {
-    const idParam = this.route.snapshot.paramMap.get("employeeId");
-    this.employeeId = Number(idParam);
+    this.routeSubscription = this.route.paramMap.subscribe((params) => {
+      const parsedId = Number(params.get("employeeId"));
 
-    if (!Number.isInteger(this.employeeId) || this.employeeId <= 0) {
-      void this.router.navigateByUrl("/funcionarios");
-      return;
-    }
+      if (!Number.isInteger(parsedId) || parsedId <= 0) {
+        void this.router.navigateByUrl("/funcionarios");
+        return;
+      }
 
-    this.loadEmployee();
-    this.loadDocuments();
+      this.employeeId = parsedId;
+      this.successMessage = "";
+      this.errorMessage = "";
+      this.loadEmployee();
+      this.loadDocuments();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.routeSubscription?.unsubscribe();
   }
 
   onFileSelected(event: Event): void {
@@ -58,25 +84,33 @@ export class EmployeeDocumentsComponent implements OnInit {
     }
 
     if (file.type !== "application/pdf") {
-      this.errorMessage = "Envie apenas arquivos PDF.";
-      this.selectedFile = null;
-      input.value = "";
+      this.ngZone.run(() => {
+        this.errorMessage = "Envie apenas arquivos PDF.";
+        this.selectedFile = null;
+        input.value = "";
+        this.changeDetectorRef.detectChanges();
+      });
       return;
     }
 
-    this.selectedFile = file;
-    this.errorMessage = "";
+    this.ngZone.run(() => {
+      this.selectedFile = file;
+      this.errorMessage = "";
+      this.changeDetectorRef.detectChanges();
+    });
   }
 
   uploadDocument(): void {
     if (!this.selectedFile) {
       this.errorMessage = "Selecione um PDF para enviar.";
+      this.changeDetectorRef.detectChanges();
       return;
     }
 
     this.isUploading = true;
     this.errorMessage = "";
     this.successMessage = "";
+    this.changeDetectorRef.detectChanges();
 
     const reader = new FileReader();
 
@@ -93,22 +127,36 @@ export class EmployeeDocumentsComponent implements OnInit {
         })
         .subscribe({
           next: () => {
-            this.isUploading = false;
-            this.successMessage = "PDF enviado para o storage e vinculado ao funcionario.";
-            this.selectedFile = null;
-            this.observacao = "";
-            this.loadDocuments();
+            this.ngZone.run(() => {
+              this.isUploading = false;
+              this.successMessage = "PDF enviado e vinculado ao funcionario.";
+              this.selectedFile = null;
+              this.observacao = "";
+
+              if (this.fileInput?.nativeElement) {
+                this.fileInput.nativeElement.value = "";
+              }
+
+              this.loadDocuments();
+              this.changeDetectorRef.detectChanges();
+            });
           },
           error: () => {
-            this.isUploading = false;
-            this.errorMessage = "Nao foi possivel enviar o documento.";
+            this.ngZone.run(() => {
+              this.isUploading = false;
+              this.errorMessage = "Nao foi possivel enviar o documento.";
+              this.changeDetectorRef.detectChanges();
+            });
           },
         });
     };
 
     reader.onerror = () => {
-      this.isUploading = false;
-      this.errorMessage = "Nao foi possivel ler o arquivo PDF.";
+      this.ngZone.run(() => {
+        this.isUploading = false;
+        this.errorMessage = "Nao foi possivel ler o arquivo PDF.";
+        this.changeDetectorRef.detectChanges();
+      });
     };
 
     reader.readAsDataURL(this.selectedFile);
@@ -117,29 +165,50 @@ export class EmployeeDocumentsComponent implements OnInit {
   openDocument(document: EmployeeDocument): void {
     const url = this.operationsApiService.resolveDocumentUrl(document.arquivoUrl);
 
-    if (url.startsWith("http://") || url.startsWith("https://")) {
+    if (!this.requiresAuthenticatedDownload(url)) {
       window.open(url, "_blank", "noopener");
       return;
     }
 
     this.http.get(url, { responseType: "blob" }).subscribe({
       next: (blob) => {
-        const objectUrl = URL.createObjectURL(blob);
-        window.open(objectUrl, "_blank", "noopener");
+        this.ngZone.run(() => {
+          const objectUrl = URL.createObjectURL(blob);
+          window.open(objectUrl, "_blank", "noopener");
+          setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
+          this.changeDetectorRef.detectChanges();
+        });
       },
       error: () => {
-        this.errorMessage = "Nao foi possivel abrir o documento.";
+        this.ngZone.run(() => {
+          this.errorMessage = "Nao foi possivel abrir o documento.";
+          this.changeDetectorRef.detectChanges();
+        });
       },
     });
+  }
+
+  private requiresAuthenticatedDownload(url: string): boolean {
+    if (url.startsWith("/api/")) {
+      return true;
+    }
+
+    return url.startsWith(API_BASE_URL) || url.includes("/api/funcionarios/documentos-arquivo/");
   }
 
   private loadEmployee(): void {
     this.employeesApiService.getEmployee(this.employeeId).subscribe({
       next: (employee) => {
-        this.employeeName = employee.nome ?? employee.name;
+        this.ngZone.run(() => {
+          this.employeeName = employee.nome ?? employee.name;
+          this.changeDetectorRef.detectChanges();
+        });
       },
       error: () => {
-        this.employeeName = `Funcionario #${this.employeeId}`;
+        this.ngZone.run(() => {
+          this.employeeName = `Funcionario #${this.employeeId}`;
+          this.changeDetectorRef.detectChanges();
+        });
       },
     });
   }
@@ -147,16 +216,23 @@ export class EmployeeDocumentsComponent implements OnInit {
   private loadDocuments(): void {
     this.isLoading = true;
     this.errorMessage = "";
+    this.changeDetectorRef.detectChanges();
 
     this.operationsApiService.listDocuments(this.employeeId).subscribe({
       next: (documents) => {
-        this.documents = documents;
-        this.isLoading = false;
+        this.ngZone.run(() => {
+          this.documents = documents;
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
       },
       error: () => {
-        this.documents = [];
-        this.errorMessage = "Nao foi possivel carregar os documentos.";
-        this.isLoading = false;
+        this.ngZone.run(() => {
+          this.documents = [];
+          this.errorMessage = "Nao foi possivel carregar os documentos.";
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
       },
     });
   }

--- a/apps/web/src/app/features/employees/employee-documents.component.ts
+++ b/apps/web/src/app/features/employees/employee-documents.component.ts
@@ -1,0 +1,163 @@
+// apps/web/src/app/features/employees/employee-documents.component.ts
+import { CommonModule } from "@angular/common";
+import { Component, OnInit, inject } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { ActivatedRoute, Router, RouterLink } from "@angular/router";
+import { HttpClient } from "@angular/common/http";
+import { EmployeesApiService } from "../../core/services/employees-api.service";
+import {
+  EmployeeDocument,
+  EmployeesOperationsApiService,
+} from "../../core/services/employees-operations-api.service";
+
+@Component({
+  selector: "pf-employee-documents",
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  templateUrl: "./employee-documents.component.html",
+  styleUrls: ["./employee-ops.shared.css", "./employee-documents.component.css"],
+})
+export class EmployeeDocumentsComponent implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly http = inject(HttpClient);
+  private readonly employeesApiService = inject(EmployeesApiService);
+  private readonly operationsApiService = inject(EmployeesOperationsApiService);
+
+  employeeId = 0;
+  employeeName = "";
+  documents: EmployeeDocument[] = [];
+  selectedFile: File | null = null;
+  dataEntrega = new Date().toISOString().slice(0, 10);
+  observacao = "";
+  isLoading = true;
+  isUploading = false;
+  errorMessage = "";
+  successMessage = "";
+
+  ngOnInit(): void {
+    const idParam = this.route.snapshot.paramMap.get("employeeId");
+    this.employeeId = Number(idParam);
+
+    if (!Number.isInteger(this.employeeId) || this.employeeId <= 0) {
+      void this.router.navigateByUrl("/funcionarios");
+      return;
+    }
+
+    this.loadEmployee();
+    this.loadDocuments();
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0] ?? null;
+
+    if (!file) {
+      this.selectedFile = null;
+      return;
+    }
+
+    if (file.type !== "application/pdf") {
+      this.errorMessage = "Envie apenas arquivos PDF.";
+      this.selectedFile = null;
+      input.value = "";
+      return;
+    }
+
+    this.selectedFile = file;
+    this.errorMessage = "";
+  }
+
+  uploadDocument(): void {
+    if (!this.selectedFile) {
+      this.errorMessage = "Selecione um PDF para enviar.";
+      return;
+    }
+
+    this.isUploading = true;
+    this.errorMessage = "";
+    this.successMessage = "";
+
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const result = String(reader.result ?? "");
+      const contentBase64 = result.includes(",") ? result.split(",")[1] : result;
+
+      this.operationsApiService
+        .uploadDocument(this.employeeId, {
+          fileName: this.selectedFile?.name ?? "documento.pdf",
+          contentBase64,
+          dataEntrega: this.dataEntrega,
+          observacao: this.observacao.trim() || undefined,
+        })
+        .subscribe({
+          next: () => {
+            this.isUploading = false;
+            this.successMessage = "PDF enviado para o storage e vinculado ao funcionario.";
+            this.selectedFile = null;
+            this.observacao = "";
+            this.loadDocuments();
+          },
+          error: () => {
+            this.isUploading = false;
+            this.errorMessage = "Nao foi possivel enviar o documento.";
+          },
+        });
+    };
+
+    reader.onerror = () => {
+      this.isUploading = false;
+      this.errorMessage = "Nao foi possivel ler o arquivo PDF.";
+    };
+
+    reader.readAsDataURL(this.selectedFile);
+  }
+
+  openDocument(document: EmployeeDocument): void {
+    const url = this.operationsApiService.resolveDocumentUrl(document.arquivoUrl);
+
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      window.open(url, "_blank", "noopener");
+      return;
+    }
+
+    this.http.get(url, { responseType: "blob" }).subscribe({
+      next: (blob) => {
+        const objectUrl = URL.createObjectURL(blob);
+        window.open(objectUrl, "_blank", "noopener");
+      },
+      error: () => {
+        this.errorMessage = "Nao foi possivel abrir o documento.";
+      },
+    });
+  }
+
+  private loadEmployee(): void {
+    this.employeesApiService.getEmployee(this.employeeId).subscribe({
+      next: (employee) => {
+        this.employeeName = employee.nome ?? employee.name;
+      },
+      error: () => {
+        this.employeeName = `Funcionario #${this.employeeId}`;
+      },
+    });
+  }
+
+  private loadDocuments(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+
+    this.operationsApiService.listDocuments(this.employeeId).subscribe({
+      next: (documents) => {
+        this.documents = documents;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.documents = [];
+        this.errorMessage = "Nao foi possivel carregar os documentos.";
+        this.isLoading = false;
+      },
+    });
+  }
+}

--- a/apps/web/src/app/features/employees/employee-ops.shared.css
+++ b/apps/web/src/app/features/employees/employee-ops.shared.css
@@ -1,0 +1,133 @@
+/* apps/web/src/app/features/employees/employee-ops.shared.css */
+.employee-ops-page {
+  display: grid;
+  gap: 1rem;
+}
+
+.employee-ops-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.employee-ops-title {
+  font-size: 1.2rem;
+  font-weight: 900;
+  letter-spacing: -0.04em;
+}
+
+.employee-ops-subtitle {
+  margin-top: 0.35rem;
+  color: var(--text-muted);
+}
+
+.employee-ops-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.timecard-panel,
+.documents-panel {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+.timecard-table-wrap {
+  overflow-x: auto;
+}
+
+.timecard-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 920px;
+}
+
+.timecard-table th,
+.timecard-table td {
+  padding: 0.75rem 0.65rem;
+  border-bottom: 1px solid var(--border);
+  text-align: center;
+  font-size: 0.82rem;
+}
+
+.timecard-table th {
+  background: #f8fafc;
+  color: #526176;
+  font-weight: 700;
+}
+
+.timecard-day {
+  font-weight: 700;
+  color: #1f2a3d;
+  background: #ffffff;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  display: inline-block;
+}
+
+.timecard-row-active td {
+  background: #ecfdf3;
+}
+
+.documents-upload {
+  display: grid;
+  gap: 1rem;
+  padding: 1.2rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.documents-upload-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.documents-upload-full {
+  grid-column: 1 / -1;
+}
+
+.documents-list {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.2rem;
+}
+
+.document-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--surface-muted);
+}
+
+.document-meta {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.document-meta strong {
+  color: #1f2a3d;
+}
+
+.document-meta span {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 720px) {
+  .employee-ops-header {
+    flex-direction: column;
+  }
+
+  .documents-upload-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/web/src/app/features/employees/employee-timecard.component.css
+++ b/apps/web/src/app/features/employees/employee-timecard.component.css
@@ -1,0 +1,30 @@
+/* apps/web/src/app/features/employees/employee-timecard.component.css */
+:host {
+  display: block;
+}
+
+.employee-ops-actions label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.operations-success,
+.operations-error {
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  border: 1px solid;
+}
+
+.operations-success {
+  border-color: #bbf7d0;
+  color: #166534;
+  background: #f0fdf4;
+}
+
+.operations-error {
+  border-color: #fecaca;
+  color: #991b1b;
+  background: #fef2f2;
+}

--- a/apps/web/src/app/features/employees/employee-timecard.component.html
+++ b/apps/web/src/app/features/employees/employee-timecard.component.html
@@ -1,0 +1,66 @@
+<div class="employee-ops-page">
+  <div class="employee-ops-header">
+    <div>
+      <div class="employee-ops-title">Cartao de ponto</div>
+      <div class="employee-ops-subtitle">{{ employeeName }} · visao diaria de entradas e saidas</div>
+    </div>
+    <div class="employee-ops-actions">
+      <a class="btn-secondary" routerLink="/funcionarios">Voltar</a>
+      <a class="btn-secondary" [routerLink]="['/funcionarios', employeeId, 'documentos']">Documentos</a>
+      <button class="btn-secondary" type="button" (click)="registerPoint('ENTRADA')">Registrar entrada</button>
+      <button class="btn-secondary" type="button" (click)="registerPoint('SAIDA')">Registrar saida</button>
+    </div>
+  </div>
+
+  <div class="employee-ops-actions">
+    <label>
+      Mes
+      <input class="form-input" type="number" min="1" max="12" [(ngModel)]="filterMonth" />
+    </label>
+    <label>
+      Ano
+      <input class="form-input" type="number" min="2020" max="2100" [(ngModel)]="filterYear" />
+    </label>
+    <button class="btn-primary" type="button" (click)="applyFilter()">Filtrar periodo</button>
+  </div>
+
+  <div *ngIf="successMessage" class="operations-success">{{ successMessage }}</div>
+  <div *ngIf="errorMessage" class="operations-error">{{ errorMessage }}</div>
+
+  <div class="timecard-panel">
+    <div *ngIf="isLoading" class="empty-state">Carregando cartao de ponto...</div>
+
+    <div *ngIf="!isLoading && dayRows.length === 0" class="empty-state">
+      Nenhum registro de ponto para o periodo selecionado (mes {{ filterMonth }}/{{ filterYear }}).
+    </div>
+
+    <div *ngIf="!isLoading && dayRows.length > 0" class="timecard-table-wrap">
+      <table class="timecard-table">
+        <thead>
+          <tr>
+            <th>Dia</th>
+            <th>Semana</th>
+            <th>Ent. 1</th>
+            <th>Sai. 1</th>
+            <th>Ent. 2</th>
+            <th>Sai. 2</th>
+            <th>Trabalhadas</th>
+            <th>Ocorrencias</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let row of dayRows; let index = index" [class.timecard-row-active]="index === 0">
+            <td><span class="timecard-day">{{ row.dateLabel }}</span></td>
+            <td>{{ row.weekday }}</td>
+            <td>{{ row.markings[0] }}</td>
+            <td>{{ row.markings[1] }}</td>
+            <td>{{ row.markings[2] }}</td>
+            <td>{{ row.markings[3] }}</td>
+            <td>{{ row.workedHours }}</td>
+            <td>{{ row.occurrences }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/apps/web/src/app/features/employees/employee-timecard.component.ts
+++ b/apps/web/src/app/features/employees/employee-timecard.component.ts
@@ -1,0 +1,213 @@
+// apps/web/src/app/features/employees/employee-timecard.component.ts
+import { CommonModule } from "@angular/common";
+import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit, inject } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { ActivatedRoute, Router, RouterLink } from "@angular/router";
+import { Subscription } from "rxjs";
+import { EmployeesApiService } from "../../core/services/employees-api.service";
+import { EmployeesOperationsApiService, PointRecord } from "../../core/services/employees-operations-api.service";
+
+type TimecardDayRow = {
+  dateKey: string;
+  dateLabel: string;
+  weekday: string;
+  markings: string[];
+  workedHours: string;
+  occurrences: string;
+};
+
+@Component({
+  selector: "pf-employee-timecard",
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  templateUrl: "./employee-timecard.component.html",
+  styleUrls: ["./employee-ops.shared.css", "./employee-timecard.component.css"],
+})
+export class EmployeeTimecardComponent implements OnInit, OnDestroy {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly employeesApiService = inject(EmployeesApiService);
+  private readonly operationsApiService = inject(EmployeesOperationsApiService);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly ngZone = inject(NgZone);
+
+  private routeSubscription?: Subscription;
+
+  employeeId = 0;
+  employeeName = "";
+  filterMonth = 5;
+  filterYear = 2026;
+  pointRecords: PointRecord[] = [];
+  dayRows: TimecardDayRow[] = [];
+  isLoading = true;
+  errorMessage = "";
+  successMessage = "";
+
+  ngOnInit(): void {
+    this.routeSubscription = this.route.paramMap.subscribe((params) => {
+      const idParam = params.get("employeeId");
+      const parsedId = Number(idParam);
+
+      if (!Number.isInteger(parsedId) || parsedId <= 0) {
+        void this.router.navigateByUrl("/funcionarios");
+        return;
+      }
+
+      this.employeeId = parsedId;
+      this.successMessage = "";
+      this.errorMessage = "";
+      this.loadEmployee();
+      this.loadPointRecords();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.routeSubscription?.unsubscribe();
+  }
+
+  goBack(): void {
+    void this.router.navigateByUrl("/funcionarios");
+  }
+
+  applyFilter(): void {
+    this.loadPointRecords();
+  }
+
+  registerPoint(tipoRegistro: "ENTRADA" | "SAIDA"): void {
+    this.operationsApiService.registerPoint(this.employeeId, tipoRegistro).subscribe({
+      next: () => {
+        this.ngZone.run(() => {
+          this.successMessage = `Ponto de ${tipoRegistro.toLowerCase()} registrado.`;
+          this.errorMessage = "";
+          this.loadPointRecords();
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+      error: () => {
+        this.ngZone.run(() => {
+          this.errorMessage = "Nao foi possivel registrar o ponto.";
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+    });
+  }
+
+  private loadEmployee(): void {
+    this.employeesApiService.getEmployee(this.employeeId).subscribe({
+      next: (employee) => {
+        this.ngZone.run(() => {
+          this.employeeName = employee.nome ?? employee.name;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+      error: () => {
+        this.ngZone.run(() => {
+          this.employeeName = `Funcionario #${this.employeeId}`;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+    });
+  }
+
+  private loadPointRecords(): void {
+    this.isLoading = true;
+    this.errorMessage = "";
+    this.changeDetectorRef.detectChanges();
+
+    this.operationsApiService
+      .listPointRecords(this.employeeId, { mes: this.filterMonth, ano: this.filterYear })
+      .subscribe({
+        next: (records) => {
+          this.ngZone.run(() => {
+            this.pointRecords = records;
+            this.dayRows = this.buildDayRows(records);
+            this.isLoading = false;
+            this.changeDetectorRef.detectChanges();
+          });
+        },
+        error: () => {
+          this.ngZone.run(() => {
+            this.pointRecords = [];
+            this.dayRows = [];
+            this.errorMessage = "Nao foi possivel carregar o cartao de ponto. Verifique login e permissao.";
+            this.isLoading = false;
+            this.changeDetectorRef.detectChanges();
+          });
+        },
+      });
+  }
+
+  private buildDayRows(records: PointRecord[]): TimecardDayRow[] {
+    const grouped = new Map<string, PointRecord[]>();
+
+    for (const record of records) {
+      const dateKey = this.toLocalDateKey(new Date(record.dataHoraBatida));
+      const bucket = grouped.get(dateKey) ?? [];
+      bucket.push(record);
+      grouped.set(dateKey, bucket);
+    }
+
+    return [...grouped.entries()]
+      .sort(([left], [right]) => right.localeCompare(left))
+      .map(([dateKey, dayRecords]) => {
+        const sorted = [...dayRecords].sort(
+          (left, right) => new Date(left.dataHoraBatida).getTime() - new Date(right.dataHoraBatida).getTime(),
+        );
+        const markings = sorted.map((record) => this.formatTime(record.dataHoraBatida));
+        const paddedMarkings = [...markings, "--:--", "--:--", "--:--", "--:--"].slice(0, 4);
+
+        return {
+          dateKey,
+          dateLabel: this.formatDateLabel(dateKey),
+          weekday: this.formatWeekday(dateKey),
+          markings: paddedMarkings,
+          workedHours: this.calculateWorkedHours(sorted),
+          occurrences: sorted.length ? "Registros do periodo" : "Sem marcacoes",
+        };
+      });
+  }
+
+  private toLocalDateKey(date: Date): string {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  private formatTime(value: string): string {
+    return new Date(value).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" });
+  }
+
+  private formatDateLabel(dateKey: string): string {
+    const [year, month, day] = dateKey.split("-");
+    return `${day}/${month}/${year}`;
+  }
+
+  private formatWeekday(dateKey: string): string {
+    const labels = ["DOM", "SEG", "TER", "QUA", "QUI", "SEX", "SAB"];
+    return labels[new Date(`${dateKey}T12:00:00`).getDay()] ?? "---";
+  }
+
+  private calculateWorkedHours(records: PointRecord[]): string {
+    let totalMinutes = 0;
+
+    for (let index = 0; index < records.length; index += 2) {
+      const entrada = records[index];
+      const saida = records[index + 1];
+
+      if (!entrada || !saida) {
+        continue;
+      }
+
+      const diff = new Date(saida.dataHoraBatida).getTime() - new Date(entrada.dataHoraBatida).getTime();
+
+      if (diff > 0) {
+        totalMinutes += Math.floor(diff / 60000);
+      }
+    }
+
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+  }
+}

--- a/apps/web/src/app/features/employees/employees.component.css
+++ b/apps/web/src/app/features/employees/employees.component.css
@@ -211,7 +211,38 @@
 }
 
 .operations-modal {
-  width: min(100%, 680px);
+  width: min(100%, 520px);
+}
+
+.operations-hub {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.operations-hub-card {
+  display: grid;
+  gap: 0.35rem;
+  text-align: left;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.operations-hub-card:hover {
+  border-color: #b8c7d9;
+  background: #f8fafc;
+}
+
+.operations-hub-card strong {
+  color: #1f2a3d;
+  font-size: 1rem;
+}
+
+.operations-hub-card span {
+  color: var(--text-muted);
+  font-size: 0.88rem;
 }
 
 .operations-actions {

--- a/apps/web/src/app/features/employees/employees.component.css
+++ b/apps/web/src/app/features/employees/employees.component.css
@@ -210,6 +210,62 @@
   background: #ffffff;
 }
 
+.operations-modal {
+  width: min(100%, 680px);
+}
+
+.operations-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.operations-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 1rem;
+}
+
+.operations-card {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--surface-muted);
+}
+
+.operations-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.operations-row:last-child {
+  border-bottom: 0;
+}
+
+.operations-success,
+.operations-error {
+  padding: 0.8rem 1rem;
+  border-radius: 12px;
+  border: 1px solid;
+}
+
+.operations-success {
+  border-color: #bbf7d0;
+  color: #166534;
+  background: #f0fdf4;
+}
+
+.operations-error {
+  border-color: #fecaca;
+  color: #991b1b;
+  background: #fef2f2;
+}
+
 @media (max-width: 900px) {
   .table-panel {
     overflow-x: auto;
@@ -226,6 +282,10 @@
   }
 
   .employee-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .operations-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/apps/web/src/app/features/employees/employees.component.html
+++ b/apps/web/src/app/features/employees/employees.component.html
@@ -196,40 +196,20 @@
     <div class="employee-modal operations-modal" (click)="$event.stopPropagation()">
       <div class="employee-modal-head">
         <div>
-          <div class="employee-modal-title">Ponto, ferias e documentos</div>
-          <div class="employee-modal-subtitle">{{ selectedEmployee.nome || selectedEmployee.name }} - API operacional fake para prototipo.</div>
+          <div class="employee-modal-title">Area operacional</div>
+          <div class="employee-modal-subtitle">{{ selectedEmployee.nome || selectedEmployee.name }} � escolha a pagina desejada</div>
         </div>
         <button class="modal-close" type="button" (click)="closeOperations()">x</button>
       </div>
-
-      <div class="employee-form">
-        <div class="operations-actions">
-          <button class="btn-secondary" type="button" (click)="registerPoint('ENTRADA')">Registrar entrada</button>
-          <button class="btn-secondary" type="button" (click)="registerPoint('SAIDA')">Registrar saida</button>
-          <button class="btn-primary" type="button" (click)="generateFakeOperations()">Gerar dados fake</button>
-        </div>
-
-        <div *ngIf="operationsMessage" class="operations-success">{{ operationsMessage }}</div>
-        <div *ngIf="operationsError" class="operations-error">{{ operationsError }}</div>
-
-        <div class="operations-grid">
-          <div class="operations-card">
-            <strong>Registros de ponto</strong>
-            <div *ngIf="isOperationsLoading" class="employee-id">Carregando...</div>
-            <div *ngIf="!isOperationsLoading && pointRecords.length === 0" class="employee-id">Nenhum ponto registrado.</div>
-            <div *ngFor="let record of pointRecords" class="operations-row">
-              <span>{{ record.tipoRegistro }}</span>
-              <strong>{{ record.dataHoraBatida | date: 'dd/MM/yyyy HH:mm' }}</strong>
-            </div>
-          </div>
-
-          <div class="operations-card">
-            <strong>Resumo vinculado</strong>
-            <div class="operations-row"><span>Ferias</span><strong>{{ selectedEmployee.ferias?.length || 0 }}</strong></div>
-            <div class="operations-row"><span>Licencas</span><strong>{{ selectedEmployee.licencas?.length || 0 }}</strong></div>
-            <div class="operations-row"><span>Atestados</span><strong>{{ selectedEmployee.atestados?.length || 0 }}</strong></div>
-          </div>
-        </div>
+      <div class="employee-form operations-hub">
+        <button class="operations-hub-card" type="button" (click)="goToTimecard()">
+          <strong>Cartao de ponto</strong>
+          <span>Ver marcacoes diarias, registrar entrada e saida.</span>
+        </button>
+        <button class="operations-hub-card" type="button" (click)="goToDocuments()">
+          <strong>Documentos</strong>
+          <span>Enviar PDF para storage e consultar arquivos vinculados.</span>
+        </button>
       </div>
     </div>
   </div>

--- a/apps/web/src/app/features/employees/employees.component.html
+++ b/apps/web/src/app/features/employees/employees.component.html
@@ -78,6 +78,11 @@
                   <path d="M4 20h4l10-10-4-4L4 16v4ZM13 7l4 4" />
                 </svg>
               </button>
+              <button class="icon-action" type="button" aria-label="Operacional funcionario" (click)="openOperations(employee)">
+                <svg viewBox="0 0 24 24" fill="none">
+                  <path d="M12 7v5l3 2M5 12a7 7 0 1 0 14 0 7 7 0 0 0-14 0Z" />
+                </svg>
+              </button>
               <button class="icon-action" type="button" aria-label="Excluir funcionario" (click)="deleteEmployee(employee.id)">
                 <svg viewBox="0 0 24 24" fill="none">
                   <path d="M5 7h14M9 7V4h6v3M8 10v7M12 10v7M16 10v7M7 7l1 13h8l1-13" />
@@ -184,6 +189,48 @@
           <button class="btn-primary" type="submit">{{ modalMode === 'edit' ? 'Salvar alteracoes' : 'Cadastrar funcionario' }}</button>
         </div>
       </form>
+    </div>
+  </div>
+
+  <div *ngIf="selectedEmployee" class="employee-modal-backdrop" (click)="closeOperations()">
+    <div class="employee-modal operations-modal" (click)="$event.stopPropagation()">
+      <div class="employee-modal-head">
+        <div>
+          <div class="employee-modal-title">Ponto, ferias e documentos</div>
+          <div class="employee-modal-subtitle">{{ selectedEmployee.nome || selectedEmployee.name }} - API operacional fake para prototipo.</div>
+        </div>
+        <button class="modal-close" type="button" (click)="closeOperations()">x</button>
+      </div>
+
+      <div class="employee-form">
+        <div class="operations-actions">
+          <button class="btn-secondary" type="button" (click)="registerPoint('ENTRADA')">Registrar entrada</button>
+          <button class="btn-secondary" type="button" (click)="registerPoint('SAIDA')">Registrar saida</button>
+          <button class="btn-primary" type="button" (click)="generateFakeOperations()">Gerar dados fake</button>
+        </div>
+
+        <div *ngIf="operationsMessage" class="operations-success">{{ operationsMessage }}</div>
+        <div *ngIf="operationsError" class="operations-error">{{ operationsError }}</div>
+
+        <div class="operations-grid">
+          <div class="operations-card">
+            <strong>Registros de ponto</strong>
+            <div *ngIf="isOperationsLoading" class="employee-id">Carregando...</div>
+            <div *ngIf="!isOperationsLoading && pointRecords.length === 0" class="employee-id">Nenhum ponto registrado.</div>
+            <div *ngFor="let record of pointRecords" class="operations-row">
+              <span>{{ record.tipoRegistro }}</span>
+              <strong>{{ record.dataHoraBatida | date: 'dd/MM/yyyy HH:mm' }}</strong>
+            </div>
+          </div>
+
+          <div class="operations-card">
+            <strong>Resumo vinculado</strong>
+            <div class="operations-row"><span>Ferias</span><strong>{{ selectedEmployee.ferias?.length || 0 }}</strong></div>
+            <div class="operations-row"><span>Licencas</span><strong>{{ selectedEmployee.licencas?.length || 0 }}</strong></div>
+            <div class="operations-row"><span>Atestados</span><strong>{{ selectedEmployee.atestados?.length || 0 }}</strong></div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/apps/web/src/app/features/employees/employees.component.ts
+++ b/apps/web/src/app/features/employees/employees.component.ts
@@ -1,9 +1,9 @@
 import { CommonModule } from "@angular/common";
-import { ChangeDetectorRef, Component, NgZone, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, NgZone, OnInit, inject } from "@angular/core";
 import { FormsModule } from "@angular/forms";
+import { Router } from "@angular/router";
 import { Employee } from "../../core/models";
 import { EmployeePayload, EmployeesApiService } from "../../core/services/employees-api.service";
-import { EmployeesOperationsApiService, PointRecord } from "../../core/services/employees-operations-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 
 type EmployeeRole = EmployeePayload["role"];
@@ -31,16 +31,14 @@ type EmployeeForm = {
   styleUrl: "./employees.component.css"
 })
 export class EmployeesComponent implements OnInit {
+  private readonly router = inject(Router);
+
   query = "";
   employees: Employee[] = [];
   isLoading = true;
   errorMessage = "";
   isModalOpen = false;
   selectedEmployee: Employee | null = null;
-  pointRecords: PointRecord[] = [];
-  operationsMessage = "";
-  operationsError = "";
-  isOperationsLoading = false;
   modalMode: "create" | "edit" = "create";
   currentPage = 1;
   pageSize = 10;
@@ -51,7 +49,6 @@ export class EmployeesComponent implements OnInit {
 
   constructor(
     private readonly employeesApiService: EmployeesApiService,
-    private readonly employeesOperationsApiService: EmployeesOperationsApiService,
     private readonly changeDetectorRef: ChangeDetectorRef,
     private readonly ngZone: NgZone,
   ) {}
@@ -185,48 +182,30 @@ export class EmployeesComponent implements OnInit {
 
   openOperations(employee: Employee): void {
     this.selectedEmployee = employee;
-    this.loadPointRecords(employee.id);
   }
 
   closeOperations(): void {
     this.selectedEmployee = null;
-    this.pointRecords = [];
-    this.operationsMessage = "";
-    this.operationsError = "";
   }
 
-  registerPoint(tipoRegistro: "ENTRADA" | "SAIDA"): void {
+  goToTimecard(): void {
     if (!this.selectedEmployee) {
       return;
     }
 
-    this.employeesOperationsApiService.registerPoint(this.selectedEmployee.id, tipoRegistro).subscribe({
-      next: () => {
-        this.operationsMessage = `Ponto de ${tipoRegistro.toLowerCase()} registrado.`;
-        this.loadPointRecords(this.selectedEmployee?.id ?? 0);
-        this.loadEmployees();
-      },
-      error: () => {
-        this.operationsError = "Nao foi possivel registrar ponto na API.";
-      },
-    });
+    const employeeId = this.selectedEmployee.id;
+    this.closeOperations();
+    void this.router.navigate(["/funcionarios", employeeId, "ponto"]);
   }
 
-  generateFakeOperations(): void {
+  goToDocuments(): void {
     if (!this.selectedEmployee) {
       return;
     }
 
-    this.employeesOperationsApiService.generateFakeOperationalData(this.selectedEmployee.id).subscribe({
-      next: () => {
-        this.operationsMessage = "Dados fake de ponto, ferias, licenca e atestado gerados.";
-        this.loadPointRecords(this.selectedEmployee?.id ?? 0);
-        this.loadEmployees();
-      },
-      error: () => {
-        this.operationsError = "Nao foi possivel gerar dados fake operacionais.";
-      },
-    });
+    const employeeId = this.selectedEmployee.id;
+    this.closeOperations();
+    void this.router.navigate(["/funcionarios", employeeId, "documentos"]);
   }
 
   formatRole(role?: string): string {
@@ -268,27 +247,6 @@ export class EmployeesComponent implements OnInit {
           this.isLoading = false;
           this.changeDetectorRef.detectChanges();
         });
-      },
-    });
-  }
-
-  private loadPointRecords(employeeId: number): void {
-    if (!employeeId) {
-      return;
-    }
-
-    this.isOperationsLoading = true;
-    this.operationsError = "";
-
-    this.employeesOperationsApiService.listPointRecords(employeeId).subscribe({
-      next: (records) => {
-        this.pointRecords = records;
-        this.isOperationsLoading = false;
-      },
-      error: () => {
-        this.pointRecords = [];
-        this.operationsError = "Nao foi possivel carregar registros de ponto.";
-        this.isOperationsLoading = false;
       },
     });
   }

--- a/apps/web/src/app/features/employees/employees.component.ts
+++ b/apps/web/src/app/features/employees/employees.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectorRef, Component, NgZone, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { Employee } from "../../core/models";
 import { EmployeePayload, EmployeesApiService } from "../../core/services/employees-api.service";
+import { EmployeesOperationsApiService, PointRecord } from "../../core/services/employees-operations-api.service";
 import { StatusBadgeComponent } from "../../shared/status-badge/status-badge.component";
 
 type EmployeeRole = EmployeePayload["role"];
@@ -35,6 +36,11 @@ export class EmployeesComponent implements OnInit {
   isLoading = true;
   errorMessage = "";
   isModalOpen = false;
+  selectedEmployee: Employee | null = null;
+  pointRecords: PointRecord[] = [];
+  operationsMessage = "";
+  operationsError = "";
+  isOperationsLoading = false;
   modalMode: "create" | "edit" = "create";
   currentPage = 1;
   pageSize = 10;
@@ -45,6 +51,7 @@ export class EmployeesComponent implements OnInit {
 
   constructor(
     private readonly employeesApiService: EmployeesApiService,
+    private readonly employeesOperationsApiService: EmployeesOperationsApiService,
     private readonly changeDetectorRef: ChangeDetectorRef,
     private readonly ngZone: NgZone,
   ) {}
@@ -176,6 +183,52 @@ export class EmployeesComponent implements OnInit {
     });
   }
 
+  openOperations(employee: Employee): void {
+    this.selectedEmployee = employee;
+    this.loadPointRecords(employee.id);
+  }
+
+  closeOperations(): void {
+    this.selectedEmployee = null;
+    this.pointRecords = [];
+    this.operationsMessage = "";
+    this.operationsError = "";
+  }
+
+  registerPoint(tipoRegistro: "ENTRADA" | "SAIDA"): void {
+    if (!this.selectedEmployee) {
+      return;
+    }
+
+    this.employeesOperationsApiService.registerPoint(this.selectedEmployee.id, tipoRegistro).subscribe({
+      next: () => {
+        this.operationsMessage = `Ponto de ${tipoRegistro.toLowerCase()} registrado.`;
+        this.loadPointRecords(this.selectedEmployee?.id ?? 0);
+        this.loadEmployees();
+      },
+      error: () => {
+        this.operationsError = "Nao foi possivel registrar ponto na API.";
+      },
+    });
+  }
+
+  generateFakeOperations(): void {
+    if (!this.selectedEmployee) {
+      return;
+    }
+
+    this.employeesOperationsApiService.generateFakeOperationalData(this.selectedEmployee.id).subscribe({
+      next: () => {
+        this.operationsMessage = "Dados fake de ponto, ferias, licenca e atestado gerados.";
+        this.loadPointRecords(this.selectedEmployee?.id ?? 0);
+        this.loadEmployees();
+      },
+      error: () => {
+        this.operationsError = "Nao foi possivel gerar dados fake operacionais.";
+      },
+    });
+  }
+
   formatRole(role?: string): string {
     const labels: Record<string, string> = {
       PROPRIETARIO: "Proprietario",
@@ -215,6 +268,27 @@ export class EmployeesComponent implements OnInit {
           this.isLoading = false;
           this.changeDetectorRef.detectChanges();
         });
+      },
+    });
+  }
+
+  private loadPointRecords(employeeId: number): void {
+    if (!employeeId) {
+      return;
+    }
+
+    this.isOperationsLoading = true;
+    this.operationsError = "";
+
+    this.employeesOperationsApiService.listPointRecords(employeeId).subscribe({
+      next: (records) => {
+        this.pointRecords = records;
+        this.isOperationsLoading = false;
+      },
+      error: () => {
+        this.pointRecords = [];
+        this.operationsError = "Nao foi possivel carregar registros de ponto.";
+        this.isOperationsLoading = false;
       },
     });
   }

--- a/apps/web/src/app/features/settings/settings.component.css
+++ b/apps/web/src/app/features/settings/settings.component.css
@@ -26,3 +26,17 @@
 .toggle.on::after {
   transform: translateX(23px);
 }
+
+.settings-error {
+  border-color: #fecaca;
+  color: #991b1b;
+}
+
+.settings-success {
+  border-color: #bbf7d0;
+  color: #166534;
+}
+
+.settings-full {
+  grid-column: 1 / -1;
+}

--- a/apps/web/src/app/features/settings/settings.component.html
+++ b/apps/web/src/app/features/settings/settings.component.html
@@ -1,32 +1,72 @@
 <div class="page-header">
   <div>
-    <div class="page-title">Configuracoes</div>
-    <div class="page-subtitle">Ajustes operacionais, seguranca e automacoes do ambiente administrativo.</div>
+    <div class="page-title">Configuracoes do chatbot</div>
+    <div class="page-subtitle">Evolution API, webhook, avisos de coleta, fiado e metricas para o proprietario.</div>
   </div>
-  <button class="btn-primary" type="button">Salvar preferencias</button>
+  <button class="btn-primary" type="button" [disabled]="isSaving" (click)="saveSettings()">
+    {{ isSaving ? "Salvando..." : "Salvar configuracoes" }}
+  </button>
 </div>
 
-<div class="row col-2">
+<div *ngIf="isLoading" class="panel">Carregando configuracoes do chatbot...</div>
+<div *ngIf="!isLoading && errorMessage" class="panel settings-error">{{ errorMessage }}</div>
+<div *ngIf="!isLoading && message" class="panel settings-success">{{ message }}</div>
+
+<div *ngIf="!isLoading" class="row col-2">
   <div class="panel">
-    <div class="panel-title">Preferencias do sistema</div>
-    <div class="catalog-list">
-      <div *ngFor="let setting of settings; let index = index; trackBy: trackByTitle" class="settings-item">
-        <div>
-          <strong>{{ setting.title }}</strong>
-          <div class="client-time">{{ setting.description }}</div>
-        </div>
-        <button class="toggle" [class.on]="setting.enabled" type="button" [attr.aria-label]="setting.title" (click)="toggleSetting(index)"></button>
+    <div class="panel-title">Integracao Evolution</div>
+    <div class="form-grid">
+      <div class="form-group">
+        <label class="form-label">URL de disparo</label>
+        <input class="form-input" name="evolutionApiUrl" [(ngModel)]="settings.evolutionApiUrl" placeholder="https://evolution.exemplo.com/message/sendText/Instancia" />
+      </div>
+      <div class="form-group">
+        <label class="form-label">API Key Evolution</label>
+        <input class="form-input" name="evolutionApiKey" [(ngModel)]="settings.evolutionApiKey" placeholder="apikey do header" />
+      </div>
+      <div class="form-group">
+        <label class="form-label">Path de envio</label>
+        <input class="form-input" name="evolutionDispatchPath" [(ngModel)]="settings.evolutionDispatchPath" placeholder="/message/sendText" />
+      </div>
+      <div class="form-group">
+        <label class="form-label">Token do webhook</label>
+        <input class="form-input" name="webhookToken" [(ngModel)]="settings.webhookToken" placeholder="token para colar na Evolution" />
+      </div>
+      <div class="form-group">
+        <label class="form-label">WhatsApp do Sr. Joaquim</label>
+        <input class="form-input" name="ownerPhone" [(ngModel)]="settings.ownerPhone" placeholder="5599999999999" />
+      </div>
+      <div class="form-group settings-full">
+        <label class="form-label">URL do webhook para colar na Evolution</label>
+        <input class="form-input" [value]="webhookUrl" readonly />
       </div>
     </div>
   </div>
 
   <div class="panel">
-    <div class="panel-title">Dados da unidade</div>
-    <div class="form-grid">
-      <div class="form-group"><label class="form-label">Nome da unidade</label><input class="form-input" value="Matriz" readonly /></div>
-      <div class="form-group"><label class="form-label">E-mail corporativo</label><input class="form-input" value="arthur@email.com" readonly /></div>
-      <div class="form-group"><label class="form-label">Perfil atual</label><input class="form-input" value="Administrador" readonly /></div>
-      <div class="form-group"><label class="form-label">Modo</label><input class="form-input" value="Angular standalone" readonly /></div>
+    <div class="panel-title">Rotas ativas do chatbot</div>
+    <div class="catalog-list">
+      <div class="settings-item">
+        <div>
+          <strong>Avisar pedido pronto</strong>
+          <div class="client-time">Envia mensagem quando o pedido estiver pronto para coleta.</div>
+        </div>
+        <button class="toggle" [class.on]="settings.orderReadyNotificationsEnabled" type="button" (click)="settings.orderReadyNotificationsEnabled = !settings.orderReadyNotificationsEnabled"></button>
+      </div>
+      <div class="settings-item">
+        <div>
+          <strong>Aviso de fiado e Serasa</strong>
+          <div class="client-time">Dispara cobranca avisando risco de envio ao Serasa.</div>
+        </div>
+        <button class="toggle" [class.on]="settings.debtWarningsEnabled" type="button" (click)="settings.debtWarningsEnabled = !settings.debtWarningsEnabled"></button>
+      </div>
+      <div class="settings-item">
+        <div>
+          <strong>Metricas diarias do proprietario</strong>
+          <div class="client-time">Libera resumo diario para o Sr. Joaquim.</div>
+        </div>
+        <button class="toggle" [class.on]="settings.dailyMetricsEnabled" type="button" (click)="settings.dailyMetricsEnabled = !settings.dailyMetricsEnabled"></button>
+      </div>
     </div>
   </div>
 </div>

--- a/apps/web/src/app/features/settings/settings.component.ts
+++ b/apps/web/src/app/features/settings/settings.component.ts
@@ -1,8 +1,10 @@
 import { CommonModule } from "@angular/common";
-import { Component } from "@angular/core";
+import { HttpErrorResponse } from "@angular/common/http";
+import { ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit } from "@angular/core";
 import { FormsModule } from "@angular/forms";
-import { StorageService } from "../../core/services/storage.service";
-import { SettingItem } from "../../core/models";
+import { NavigationEnd, Router } from "@angular/router";
+import { Subscription, filter } from "rxjs";
+import { ChatbotApiService, ChatbotSettings } from "../../core/services/chatbot-api.service";
 
 @Component({
   selector: "pf-settings",
@@ -11,19 +13,108 @@ import { SettingItem } from "../../core/models";
   templateUrl: "./settings.component.html",
   styleUrl: "./settings.component.css"
 })
-export class SettingsComponent {
-  settings = this.storageService.getSettings();
+export class SettingsComponent implements OnInit, OnDestroy {
+  settings: ChatbotSettings = {
+    evolutionApiUrl: "",
+    evolutionApiKey: "",
+    evolutionDispatchPath: "/message/sendText",
+    webhookToken: "",
+    ownerPhone: "",
+    orderReadyNotificationsEnabled: true,
+    debtWarningsEnabled: true,
+    dailyMetricsEnabled: true,
+  };
+  isLoading = true;
+  isSaving = false;
+  message = "";
+  errorMessage = "";
+  private readonly routeSubscription: Subscription;
 
-  constructor(private readonly storageService: StorageService) {}
-
-  toggleSetting(index: number): void {
-    this.settings = this.settings.map((setting, currentIndex) =>
-      currentIndex === index ? { ...setting, enabled: !setting.enabled } : setting
-    );
-    this.storageService.saveSettings(this.settings);
+  constructor(
+    private readonly chatbotApiService: ChatbotApiService,
+    private readonly router: Router,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly ngZone: NgZone,
+  ) {
+    this.routeSubscription = this.router.events
+      .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
+      .subscribe((event) => {
+        if (event.urlAfterRedirects.startsWith("/configuracoes")) {
+          this.loadSettings();
+        }
+      });
   }
 
-  trackByTitle(_: number, item: SettingItem): string {
-    return item.title;
+  ngOnInit(): void {
+    this.loadSettings();
+  }
+
+  ngOnDestroy(): void {
+    this.routeSubscription.unsubscribe();
+  }
+
+  get webhookUrl(): string {
+    return `${window.location.origin.replace(/\/+$/, "")}/api/chatbot/webhook/evolution?token=${encodeURIComponent(this.settings.webhookToken || "TOKEN_DO_PAINEL")}`;
+  }
+
+  loadSettings(): void {
+    this.isLoading = true;
+    this.message = "";
+    this.errorMessage = "";
+    this.changeDetectorRef.detectChanges();
+
+    this.chatbotApiService.getSettings().subscribe({
+      next: (settings) => {
+        this.ngZone.run(() => {
+          this.settings = settings;
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+      error: (error: HttpErrorResponse) => {
+        this.ngZone.run(() => {
+          this.errorMessage = this.getApiErrorMessage(error, "carregar");
+          this.isLoading = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+    });
+  }
+
+  saveSettings(): void {
+    this.isSaving = true;
+    this.message = "";
+    this.errorMessage = "";
+    this.changeDetectorRef.detectChanges();
+
+    this.chatbotApiService.updateSettings(this.settings).subscribe({
+      next: (settings) => {
+        this.ngZone.run(() => {
+          this.settings = settings;
+          this.message = "Configuracoes do chatbot salvas na API.";
+          this.isSaving = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+      error: (error: HttpErrorResponse) => {
+        this.ngZone.run(() => {
+          this.errorMessage = this.getApiErrorMessage(error, "salvar");
+          this.isSaving = false;
+          this.changeDetectorRef.detectChanges();
+        });
+      },
+    });
+  }
+
+  private getApiErrorMessage(error: HttpErrorResponse, action: "carregar" | "salvar"): string {
+    if (error.status === 401) {
+      return "Sessao expirada ou token invalido. Faca login novamente.";
+    }
+
+    if (error.status === 403) {
+      return "Apenas o proprietario pode acessar as configuracoes do chatbot.";
+    }
+
+    return `Nao foi possivel ${action} configuracoes do chatbot.`;
   }
 }

--- a/apps/web/src/app/layout/shell/shell.component.css
+++ b/apps/web/src/app/layout/shell/shell.component.css
@@ -278,6 +278,29 @@
   color: #7b8798;
 }
 
+.admin-email {
+  font-size: 11px;
+  color: #94a3b8;
+  margin-top: 2px;
+}
+
+.logout-btn {
+  border: 1px solid #d7e2ee;
+  background: #ffffff;
+  color: #334155;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.logout-btn:hover {
+  background: #f8fafc;
+  border-color: #b8c7d9;
+}
+
 .admin-avatar {
   width: 38px;
   height: 38px;

--- a/apps/web/src/app/layout/shell/shell.component.html
+++ b/apps/web/src/app/layout/shell/shell.component.html
@@ -151,10 +151,12 @@
 
         <div class="admin-chip topbar-divider">
           <div class="admin-info">
-            <div class="admin-name">Administrador</div>
-            <div class="admin-unit">Unidade Matriz</div>
+            <div class="admin-name">{{ userDisplayName }}</div>
+            <div class="admin-unit">{{ userSubtitle }}</div>
+            <div class="admin-email" *ngIf="userEmail">{{ userEmail }}</div>
           </div>
-          <div class="admin-avatar">A</div>
+          <div class="admin-avatar" [attr.title]="userEmail">{{ userInitials }}</div>
+          <button class="logout-btn" type="button" (click)="logout()">Sair</button>
         </div>
       </div>
     </header>

--- a/apps/web/src/app/layout/shell/shell.component.ts
+++ b/apps/web/src/app/layout/shell/shell.component.ts
@@ -3,7 +3,7 @@ import { Component, inject } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { ActivatedRoute, NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from "@angular/router";
 import { filter, map, startWith } from "rxjs";
-import { AuthService } from "../../core/services/auth.service";
+import { AuthService, AuthUser } from "../../core/services/auth.service";
 import { ZoomService } from "../../core/services/zoom.service";
 import { NAV_ITEMS, getPageMeta } from "../../core/navigation";
 
@@ -61,6 +61,51 @@ export class ShellComponent {
 
   get zoomScale(): string {
     return `${this.zoom()}%`;
+  }
+
+  get currentUser(): AuthUser | null {
+    return this.authService.getUser();
+  }
+
+  get userDisplayName(): string {
+    return this.currentUser?.nome?.trim() || "Usuario";
+  }
+
+  get userSubtitle(): string {
+    const user = this.currentUser;
+    if (!user) {
+      return "Sessao ativa";
+    }
+
+    const roleLabel = this.formatRole(user.role);
+    return user.cargo ? `${user.cargo} · ${roleLabel}` : roleLabel;
+  }
+
+  get userEmail(): string {
+    return this.currentUser?.email ?? "";
+  }
+
+  get userInitials(): string {
+    const parts = this.userDisplayName.split(/\s+/).filter(Boolean);
+    if (parts.length === 0) {
+      return "?";
+    }
+
+    if (parts.length === 1) {
+      return parts[0].slice(0, 2).toUpperCase();
+    }
+
+    return `${parts[0][0] ?? ""}${parts[parts.length - 1][0] ?? ""}`.toUpperCase();
+  }
+
+  private formatRole(role: AuthUser["role"]): string {
+    const labels: Record<AuthUser["role"], string> = {
+      PROPRIETARIO: "Proprietario",
+      ATENDENTE: "Atendente",
+      PADEIRO: "Padeiro",
+    };
+
+    return labels[role] ?? role;
   }
 
   logout(): void {


### PR DESCRIPTION
## Summary
- Integra configuracao do chatbot/Evolution no painel de Configuracoes e rotas da API.
- Adiciona hub operacional em Funcionarios com paginas dedicadas de cartao de ponto e documentos (upload PDF).
- Exibe usuario logado e botao Sair no topo; corrige atualizacao da UI nas telas de ponto.
- Inclui seed de marcacoes historicas (01/05 a 18/05/2026) via \
pm run ponto:seed --workspace @padaria/api\.
- Upload de PDF usa Supabase quando credenciais sao validas; caso contrario faz fallback para \.runtime/documentos\ (evita erro Invalid Compact JWS).

## Test plan
- [ ] Login como proprietario (joaquim@paofresquim.com)
- [ ] Configuracoes: salvar URL/key do Evolution
- [ ] Funcionarios > relogio > Cartao de ponto (mes 5 / 2026)
- [ ] Funcionarios > Documentos: enviar PDF e abrir na lista
- [ ] Verificar chatbot e rotas protegidas por role
